### PR TITLE
drop amd analysis support

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -105,58 +105,11 @@ class AnalyzerTransform extends Plugin {
 
   _parseImports(source) {
     let ast = babelParser.parse(source, { sourceType: 'module' });
-    let amdImports = {};
-    let es6Imports = {};
-
-    forEachNode(ast, function(entry) {
-      if (entry.type === 'CallExpression' && entry.callee.name === 'define') {
-        findAMDImports(entry, amdImports);
-      } else if (entry.type === 'ImportDeclaration') {
-        findES6Imports(entry, es6Imports);
-      }
-    });
-
-    // If any ES6 import statements were found, ignore anything that looked like a module `define` invocation
-    if (Object.keys(es6Imports).length) {
-      return es6Imports;
-    } else {
-      return amdImports;
-    }
+    // No need to recurse here, because we only deal with top-level static import declarations
+    return ast.program.body.filter(node => node.type === 'ImportDeclaration').map(node => node.source.value);
   }
 }
 
-
-function forEachNode(node, visit) {
-  if (node && typeof node === 'object' && !node._eb_visited) {
-    node._eb_visited = true;
-    visit(node);
-    let keys = Object.keys(node);
-    for (let i=0; i < keys.length; i++) {
-      forEachNode(node[keys[i]], visit);
-    }
-  }
-}
-
-function head(array) {
-  return array[0];
-}
-
-function findAMDImports(entry, imports) {
-  debug('doing AMD import analysis');
-  head(entry.arguments.filter(function(item) {
-    return item.type === 'ArrayExpression';
-  })).elements.filter(function(element) {
-    return element.value !== 'exports';
-  }).forEach(function(element) {
-    imports[element.value] = true;
-  });
-}
-
-function findES6Imports(entry, imports) {
-  debug('doing ES6 import analysis');
-  let source = entry.source.value;
-  imports[source] = true;
-}
 
 function copy(sourcePath, destPath) {
   let destDir = dirname(destPath);
@@ -179,7 +132,7 @@ function copy(sourcePath, destPath) {
 function groupModules(paths) {
   let targets = Object.create(null);
   Object.keys(paths).forEach(inPath => {
-    Object.keys(paths[inPath]).forEach(module => {
+    paths[inPath].forEach(module => {
       if (!targets[module]) {
         targets[module] = [];
       }


### PR DESCRIPTION
This was only needed because of the point at which we used to hook into the build pipeline. Now we always see the original ES module sources.