### PR TITLE
fix for missing tree in some older ember-cli versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,6 @@ module.exports = {
       tree,
       debugTree(appBundler.tree, 'app'),
       debugTree(testsBundler.tree, 'tests')
-    ]);
+    ].filter(Boolean));
   }
 };


### PR DESCRIPTION
If you don't have a vendor folder, under some conditions `tree` will be undefined here and cause an exception.