### PR TITLE
Support ember-cli-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "configPath": "tests/dummy/config",
     "before": [
       "ember-cli-babel"
+    ],
+    "after": [
+      "ember-cli-typescript"
     ]
   }
 }


### PR DESCRIPTION
`ember-auto-import` currently does not work correctly with [`ember-cli-typescript`](https://github.com/typed-ember/ember-cli-typescript) because it runs before `ember-cli-typescript` has compiled .ts files to .js. This PR forces `ember-auto-import` to run after `ember-cli-typescript` so  that the analyzer finds the compiled .js files in the tree.