### PR TITLE
fix module deletion

### DIFF
--- a/ts/analyzer.ts
+++ b/ts/analyzer.ts
@@ -85,9 +85,11 @@ export default class Analyzer extends Plugin {
 
   removeImports(relativePath) {
     debug(`removing imports for ${relativePath}`);
-    if (this.paths[relativePath] && this.paths[relativePath].length > 0){
-      this.paths[relativePath] = null;
-      this.modules = null; // invalidates cache
+    if (this.paths[relativePath]) {
+      if (this.paths[relativePath].length > 0){
+        this.modules = null; // invalidates cache
+      }
+      delete this.paths[relativePath];
     }
   }
 


### PR DESCRIPTION
Fixes #36 by not leaving empty values in `this.paths`. Plus this tightens up the handling of modules with no imports (they should also get removed from this.paths when deleted, but should not invalidate the cache).