### PR TITLE
fixing paths in Window OS

### DIFF
--- a/ts/webpack.ts
+++ b/ts/webpack.ts
@@ -41,8 +41,12 @@ export default class WebpackBundler {
   }
 
   private writeEntryFile(modules){
-    let moduleList = Object.keys(modules).map(specifier => ({ specifier, entrypoint: modules[specifier].entrypoint}));
+    let moduleList = Object.keys(modules).map(specifier => ({ specifier, entrypoint: this.normalizePath(modules[specifier].entrypoint) }));
     writeFileSync(join(this.stagingDir, 'entry.js'), entryTemplate({ modules: moduleList }));
+  }
+
+  private normalizePath(entrypoint) {
+    return entrypoint.replace(/\\/g, '\\\\');
   }
 
   private async runWebpack(){


### PR DESCRIPTION
hi  @ef4 : 

when we use this in window,  building is failed  : 

```
ERROR in ./tmp/ember_auto_import_webpack-staging_dir-EqQ18vBa.tmp/entry.js 10:136
Module parse failed: Bad character escape sequence (10:136)
You may need an appropriate loader to handle this file type.
|     window.define('numeral', [], function() { return require('E:\work\js\node_modules\numeral\numeral.js'); });
>     window.define('node-uuid', [], function() { return require('E:\work\js\node_modules\node-uuid\uuid.js'); });

```


so, i  pull this request for you  to fix the path problem .
