### PR TITLE
Add alias option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ You can set options like this in your ember-cli-build.js:
 // In your ember-cli-build.js file
 let app = new EmberApp(defaults, {
   autoImport: {
+    alias: {
+      // when the app tries to import from "plotly.js", use
+      // the real package "plotly.js-basic-dist" instead.
+      'plotly.js': 'plotly.js-basic-dist',
+
+      // you can also use alises to pick a different entrypoint
+      // within the same package. This can come up when the default
+      // entrypoint only works in Node, but there is also a browser
+      // build available (and the author didn't provide a "browser"
+      // field in package.json that would let us detect it
+      // automatically).
+      'handlebars': 'handlebars/dist/handlebars'
+    },
     exclude: ['some-package'],
     webpack: {
       // extra webpack configuration goes here
@@ -55,6 +68,7 @@ let app = new EmberApp(defaults, {
 
 Suported Options
 
+ - `alias`: _object_, Map from package names to substitute packages that will be used instead.
  - `exclude`: _list of strings, defaults to []_. Packages in this list will be ignored by ember-auto-import. Can be helpful if the package is already included another way (like a shim from some other Ember addon).
  - `webpack`: _object_, An object that will get merged into the configuration we pass to webpack. This lets you work around quirks in underlying libraries and otherwise customize the way Webpack will assemble your dependencies.
 
@@ -109,7 +123,7 @@ Contributing
 
 ### Running tests
 
-Our test setup is not typical for an Ember addon. While there is a normal Ember addon dummy app that you can run the normal way (with `ember test`), we also have multiple other apps under `/test-apps`. This lets us test how ember-auto-import gets integrated under multiple scenarios. 
+Our test setup is not typical for an Ember addon. While there is a normal Ember addon dummy app that you can run the normal way (with `ember test`), we also have multiple other apps under `/test-apps`. This lets us test how ember-auto-import gets integrated under multiple scenarios.
 
 The test apps share the top-level node_modules automatically, no need to run separate npm installs for them. They should get symlinked to each other automatically when you install the top-level deps (see `./scripts/link-them.sh`). You can also `cd` directly into any of the test apps and run its tests like a normal Ember app.
 

--- a/test-apps/sample-direct/app/components/hello-world.js
+++ b/test-apps/sample-direct/app/components/hello-world.js
@@ -2,12 +2,17 @@ import Component from '@ember/component';
 import layout from '../templates/components/hello-world';
 import moment from 'moment';
 import { computed } from '@ember/object';
+import innerLib2 from 'my-aliased-module';
 
 export default Component.extend({
   layout,
 
   formattedDate: computed(function() {
     return moment('2018-05-31T18:03:01.791Z').format('YYYY-MM-DD');
+  }),
+
+  aliasedResult: computed(function () {
+    return innerLib2();
   }),
 
   // Our test suite imports lodash-es, but our app does not, so it

--- a/test-apps/sample-direct/app/templates/components/hello-world.hbs
+++ b/test-apps/sample-direct/app/templates/components/hello-world.hbs
@@ -1,2 +1,3 @@
 <div class="hello-world">{{formattedDate}}</div>
 <div class="lodash">{{#if lodashPresent}}yes{{else}}no{{/if}}</div>
+<div class="aliased">{{aliasedResult}}</div>

--- a/test-apps/sample-direct/ember-cli-build.js
+++ b/test-apps/sample-direct/ember-cli-build.js
@@ -5,7 +5,10 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     autoImport: {
-      exclude: ['qunit']
+      exclude: ['qunit'],
+      alias: {
+        'my-aliased-module': 'inner-lib2'
+      }
     }
   });
 

--- a/test-apps/sample-direct/package.json
+++ b/test-apps/sample-direct/package.json
@@ -46,7 +46,8 @@
     "loader.js": "*",
     "lodash-es": "*",
     "moment": "*",
-    "qunit": "*"
+    "qunit": "*",
+    "inner-lib2": "*"
   },
   "engines": {
     "node": ">= 8.*"

--- a/test-apps/sample-direct/tests/acceptance/basics-test.js
+++ b/test-apps/sample-direct/tests/acceptance/basics-test.js
@@ -9,4 +9,10 @@ module('sample-direct | Acceptance | basics', function(hooks) {
     await visit('/');
     assert.equal(document.querySelector('.hello-world').textContent.trim(), '2018-05-31');
   });
+
+  test('using an aliased module', async function(assert) {
+    await visit('/');
+    assert.equal(document.querySelector('.aliased').textContent.trim(), 'innerlib2 loaded');
+  });
+
 });

--- a/ts/package.ts
+++ b/ts/package.ts
@@ -84,4 +84,12 @@ export default class Package {
     get webpackConfig() : any{
         return this.autoImportOptions && this.autoImportOptions.webpack;
     }
+
+    aliasFor(name) : string {
+      return (
+        this.autoImportOptions &&
+        this.autoImportOptions.alias &&
+        this.autoImportOptions.alias[name]
+      ) || name;
+    }
 }

--- a/ts/splitter.ts
+++ b/ts/splitter.ts
@@ -68,9 +68,10 @@ export default class Splitter {
         return;
       }
 
-      let parts = specifier.split('/');
+      let aliasedSpecifier = pkg.aliasFor(specifier);
+      let parts = aliasedSpecifier.split('/');
       let packageName;
-      if (specifier[0] === '@') {
+      if (aliasedSpecifier[0] === '@') {
         packageName = `${parts[0]}/${parts[1]}`;
       } else {
         packageName = parts[0];
@@ -86,7 +87,7 @@ export default class Splitter {
       }
       pkg.assertAllowedDependency(packageName);
 
-      let entrypoint = await resolveEntrypoint(specifier, pkg);
+      let entrypoint = await resolveEntrypoint(aliasedSpecifier, pkg);
       let seenAlready = specifiers[specifier];
       if (seenAlready){
         if (seenAlready.entrypoint !== entrypoint) {


### PR DESCRIPTION
This adds module aliasing to ember-auto-import's configuration options. While this is already a feature in webpack config, we need to make decisions about dependencies before we ever hand off to webpack, so it's appropriate that this config (along with "exclude") belongs in ember-auto-import proper.

Closes #51.