### PR TITLE
Add debugging of output via broccoli-debug

### DIFF
--- a/ts/auto-import.ts
+++ b/ts/auto-import.ts
@@ -86,6 +86,8 @@ export default class AutoImport{
     }
 
     treeForVendor(tree){
-        return new MergeTrees([tree].concat(this.bundlers.map(b => b.tree)).filter(Boolean));
+        let trees = [tree].concat(this.bundlers.map(b => b.tree)).filter(Boolean);
+
+        return debugTree(new MergeTrees(trees), 'vendor:output');
     }
 }


### PR DESCRIPTION
This allows easier debugging of the webpack build output for both app and test bundles.

When using:

```
BROCCOLI_DEBUG=ember-auto-import:* ember build
```

You will now see both the `DEBUG/ember-auto-import/preprocessor/input` files (which were previously available) and `DEBUG/ember-auto-import/vendor/output/` files.

---

This _should_ help isolate which packages are responsible for the issue in https://github.com/ef4/ember-auto-import/issues/58 (e.g. is webpack just emitting invalid values, is something later in the pipeline mucking up the sourcemap comment, etc...