### PR TITLE
cleaner public tree output

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "debug": "^3.1.0",
     "ember-cli-babel": "^6.6.0",
     "enhanced-resolve": "^4.0.0",
+    "fs-extra": "^6.0.1",
     "fs-tree-diff": "^0.5.7",
     "handlebars": "^4.0.11",
     "js-string-escape": "^1.0.1",
@@ -51,6 +52,7 @@
     "webpack": "^4.12.0"
   },
   "devDependencies": {
+    "@types/fs-extra": "^5.0.4",
     "@types/lodash": "^4.14.110",
     "@types/node": "^10.3.4",
     "babel-eslint": "^8.2.5",

--- a/ts/auto-import.ts
+++ b/ts/auto-import.ts
@@ -80,7 +80,7 @@ export default class AutoImport{
 
     treeForPublic() {
       return debugTree(new Funnel(this.makeTree(), {
-        srcDir: 'ember-auto-import',
+        srcDir: 'ember-auto-import/lazy',
         destDir: 'assets',
         // these files were already app.imported from treeForVendor. Anything
         // else that remains is a lazy chunk.
@@ -90,7 +90,7 @@ export default class AutoImport{
 
     appImports(importFn) {
       for (let bundle of bundles) {
-        importFn(`vendor/ember-auto-import/combined-${bundle}.js`, bundleOptions(bundle));
+        importFn(`vendor/ember-auto-import/entry/${bundle}.js`, bundleOptions(bundle));
       }
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,9 +100,19 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
 
+"@types/fs-extra@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-5.0.4.tgz#b971134d162cc0497d221adde3dbb67502225599"
+  dependencies:
+    "@types/node" "*"
+
 "@types/lodash@^4.14.110":
   version "4.14.110"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.110.tgz#fb07498f84152947f30ea09d89207ca07123461e"
+
+"@types/node@*":
+  version "10.5.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
 
 "@types/node@^10.3.4":
   version "10.3.4"
@@ -1440,13 +1450,6 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
-broccoli-merge-trees@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.0.tgz#90e4959f9e3c57cf1f04fab35152f3d849468d8b"
-  dependencies:
-    broccoli-plugin "^1.3.0"
-    merge-trees "^2.0.0"
-
 broccoli-middleware@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.2.1.tgz#a21f255f8bfe5a21c2f0fbf2417addd9d24c9436"
@@ -1880,10 +1883,6 @@ clean-css@^3.4.5:
   dependencies:
     commander "2.8.x"
     source-map "0.4.x"
-
-clean-up-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -3573,6 +3572,14 @@ fs-extra@^5.0.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-6.0.1.tgz#8abc128f7946e310135ddc93b98bddb410e7a34b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.5.tgz#06c277218454ec288df77ada54a03b8702aacb9d"
@@ -3587,16 +3594,6 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     object-assign "^4.1.0"
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
-
-fs-updater@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
-  dependencies:
-    can-symlink "^1.0.0"
-    clean-up-path "^1.0.0"
-    heimdalljs "^0.2.5"
-    heimdalljs-logger "^0.1.9"
-    rimraf "^2.6.2"
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -3900,7 +3897,7 @@ heimdalljs-logger@^0.1.7, heimdalljs-logger@^0.1.9:
     debug "^2.2.0"
     heimdalljs "^0.2.0"
 
-heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5:
+heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
   dependencies:
@@ -5144,13 +5141,6 @@ merge-trees@^1.0.1:
     heimdalljs-logger "^0.1.7"
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
-
-merge-trees@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
-  dependencies:
-    fs-updater "^1.0.4"
-    heimdalljs "^0.2.5"
 
 merge@^1.1.3:
   version "1.2.0"


### PR DESCRIPTION
Previously, we would sometimes allow webpack output files to appear in your app's final build that were not actually needed there. Now we only emit the ones that are needed (for lazy loading).