### PR TITLE
automatically configure fingerprinting for prod

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -25,7 +25,7 @@ module.exports = {
     let autoImport = AutoImport.lookup(this);
     this._super.included.apply(this, arguments);
     if (autoImport.isPrimary(this)){
-      autoImport.appImports(this.import.bind(this));
+      autoImport.included(this);
     }
   },
 

--- a/ts/webpack.ts
+++ b/ts/webpack.ts
@@ -54,9 +54,7 @@ export default class WebpackBundler implements BundlerHook {
       output: {
         path: join(this.outputDir, 'webpack-out'),
         filename: `[id].js`,
-        // this is chosen so we can easily find all the chunks when we want to
-        // consume them in fastboot
-        chunkFilename: `chunk.[id].js`,
+        chunkFilename: `chunk.[chunkhash].js`,
         libraryTarget: 'var',
         library: '__ember_auto_import__'
       },


### PR DESCRIPTION
We don't want broccoli-asset-rev to rename our lazy chunks, because the webpack runtime loader won't be able to find them, and they already have hashes in their names anyway.