### PR TITLE
always set public path

### DIFF
--- a/ts/webpack.ts
+++ b/ts/webpack.ts
@@ -12,13 +12,11 @@ registerHelper('js-string-escape', jsStringEscape);
 
 const entryTemplate = compile(`
 {{! locate the webpack lazy loaded chunks relative to our vendor script }}
-{{#if dynamicImports}}
 if (typeof document !== 'undefined') {
 __webpack_public_path__ = Array.prototype.slice.apply(document.querySelectorAll('script'))
   .find(function(s){ return /\\/vendor/.test(s.src); })
   .src.replace(/\\/vendor.*/, '/');
 }
-{{/if}}
 
 module.exports = (function(){
   var w = window;


### PR DESCRIPTION
Right now we only set the public path if we have discovered some dynamic imports. But that isn't right -- even if all our own imports are static, some of _those_ packages may have dynamic imports. So we should always do public path discovery.

Closes #64.