### PR TITLE
change public asset URL heuristic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EAI_SCENARIO=canary
+    - env: EAI_SCENARIO=beta
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Suported Options
 
  - `alias`: _object_, Map from package names to substitute packages that will be used instead.
  - `exclude`: _list of strings, defaults to []_. Packages in this list will be ignored by ember-auto-import. Can be helpful if the package is already included another way (like a shim from some other Ember addon).
+ - `publicAssetURL`: where to load additional dynamic javascript files from. You usually don't need to set this -- the default works for any Ember app that isn't doing something unusual.
  - `webpack`: _object_, An object that will get merged into the configuration we pass to webpack. This lets you work around quirks in underlying libraries and otherwise customize the way Webpack will assemble your dependencies.
 
 Usage from Addons

--- a/ts/bundler.ts
+++ b/ts/bundler.ts
@@ -32,6 +32,21 @@ class BundlerPlugin extends Plugin {
     super([placeholderTree], { persistentOutput: true });
   }
 
+  private get publicAssetURL() : string|undefined {
+    // Only the app (not an addon) can customize the public asset URL, because
+    // it's an app concern.
+    let rootPackage = [...this.options.packages.values()].find(pkg => !pkg.isAddon);
+    if (rootPackage) {
+      let url = rootPackage.publicAssetURL;
+      if (url) {
+        if (url[url.length-1] !== '/') {
+          url = url + '/';
+        }
+        return url;
+      }
+    }
+  }
+
   get bundlerHook() : BundlerHook {
     if (!this.cachedBundlerHook){
       let extraWebpackConfig = merge({}, ...[...this.options.packages.values()].map(pkg => pkg.webpackConfig));
@@ -41,7 +56,8 @@ class BundlerPlugin extends Plugin {
         this.outputPath,
         this.options.environment,
         extraWebpackConfig,
-        this.options.consoleWrite
+        this.options.consoleWrite,
+        this.publicAssetURL
       );
     }
     return this.cachedBundlerHook;

--- a/ts/package.ts
+++ b/ts/package.ts
@@ -119,4 +119,8 @@ export default class Package {
         this.autoImportOptions.alias[name]
       ) || name;
     }
+
+    get publicAssetURL(): string|undefined {
+      return this.autoImportOptions && this.autoImportOptions.publicAssetURL;
+    }
 }


### PR DESCRIPTION
Now instead of searching for a Javascript file whose name starts with "vendor", we just assume our own code is being synchronously loaded, which allows us to locate it relative to ourself.

In addition, this can now be overridden with a public option.