### PR TITLE
Refactoring for compatibility with newer ember-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,6 @@ env:
     - EAI_SCENARIO=beta
     - EAI_SCENARIO=canary
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EAI_SCENARIO=canary
-    - env: EAI_SCENARIO=beta
-
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH

--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "before": [
-      "ember-cli-babel",
-      "ember-cli-concat"
+      "ember-cli-babel"
     ],
     "after": [
       "ember-cli-coffeescript",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
     "babylon": "^6.18.0",
     "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.4",
-    "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^3.0.0",
     "broccoli-plugin": "^1.3.0",
-    "broccoli-source": "^1.1.0",
     "debug": "^3.1.0",
     "ember-cli-babel": "^6.6.0",
     "enhanced-resolve": "^4.0.0",
@@ -95,7 +94,8 @@
   "ember-addon": {
     "configPath": "tests/dummy/config",
     "before": [
-      "ember-cli-babel"
+      "ember-cli-babel",
+      "ember-cli-concat"
     ],
     "after": [
       "ember-cli-coffeescript",

--- a/ts/auto-import.ts
+++ b/ts/auto-import.ts
@@ -81,10 +81,14 @@ export default class AutoImport{
       // We also cannot use postprocessTree('all'), because that only works in
       // first-level addons.
       //
-      // So we are forced to monkey patch EmberApp.
-      let originalToTree = host.toTree.bind(host);
-      host.toTree = (...args) => {
-        return this.addTo(originalToTree(...args));
+      // So we are forced to monkey patch EmberApp. We insert ourselves right at
+      // the beginning of addonPostprocessTree.
+      let original = host.addonPostprocessTree.bind(host);
+      host.addonPostprocessTree = (which, tree) => {
+        if (which === 'all') {
+          tree = this.addTo(tree);
+        }
+        return original(which, tree);
       };
     }
 

--- a/ts/auto-import.ts
+++ b/ts/auto-import.ts
@@ -3,8 +3,8 @@ import Bundler from './bundler';
 import Analyzer from './analyzer';
 import Package from './package';
 import { buildDebugCallback } from 'broccoli-debug';
-import Funnel from 'broccoli-funnel';
-import { bundles, bundleForPath, bundleOptions } from './bundle-config';
+import { bundles, bundleForPath } from './bundle-config';
+import mergeTrees from 'broccoli-merge-trees';
 
 const debugTree = buildDebugCallback('ember-auto-import');
 const protocol = '__ember_auto_import_protocol_v1__';
@@ -15,8 +15,6 @@ export default class AutoImport{
     private env: string;
     private consoleWrite: (string) => void;
     private analyzers: Map<Analyzer, Package> = new Map();
-    private bundler: Bundler;
-    private tree;
 
     static lookup(appOrAddon) : AutoImport {
         if (!global[protocol]) {
@@ -32,7 +30,6 @@ export default class AutoImport{
         if (!this.env) { throw new Error("Bug in ember-auto-import: did not discover environment"); }
 
         this.consoleWrite = (...args) => appOrAddon.project.ui.write(...args);
-        this.bundler = this.makeBundler();
     }
 
     isPrimary(appOrAddon){
@@ -44,11 +41,10 @@ export default class AutoImport{
         this.packages.add(pack);
         let analyzer = new Analyzer(debugTree(tree, `preprocessor:input-${this.analyzers.size}`), pack);
         this.analyzers.set(analyzer, pack);
-        this.bundler.unsafeConnect(analyzer);
         return analyzer;
     }
 
-    private makeBundler() {
+    addTo(allAppTree) {
         // The Splitter takes the set of imports from the Analyzer and
         // decides which ones to include in which bundles
         let splitter = new Splitter({
@@ -59,37 +55,37 @@ export default class AutoImport{
 
         // The Bundler asks the splitter for deps it should include and
         // is responsible for packaging those deps up.
-        return new Bundler({
+        let bundler = new Bundler(allAppTree, {
           splitter,
           environment: this.env,
           packages: this.packages,
           consoleWrite: this.consoleWrite
         });
-    }
 
-    private makeTree() {
-      if (!this.tree) {
-        this.tree = debugTree(this.bundler.tree, 'output');
-      }
-      return this.tree;
-    }
-
-    treeForVendor(){
-      return this.makeTree();
-    }
-
-    treeForPublic() {
-      return debugTree(new Funnel(this.makeTree(), {
-        srcDir: 'ember-auto-import/lazy',
-        destDir: 'assets'
-      }), 'public');
+        return mergeTrees([
+          allAppTree,
+          debugTree(bundler, 'output')
+        ], { overwrite: true });
     }
 
     included(addonInstance) {
-      for (let bundle of bundles) {
-        addonInstance.import(`vendor/ember-auto-import/entry/${bundle}.js`, bundleOptions(bundle));
-      }
-      this.configureFingerprints(addonInstance._findHost());
+      let host = addonInstance._findHost();
+      this.configureFingerprints(host);
+
+      // ember-cli as of 3.4-beta has introduced architectural changes that make
+      // it impossible for us to nicely emit the built dependencies via our own
+      // vendor and public trees, because it now considers those as *inputs* to
+      // the trees that we analyze, causing a circle, even though there is no
+      // real circular data dependency.
+      //
+      // We also cannot use postprocessTree('all'), because that only works in
+      // first-level addons.
+      //
+      // So we are forced to monkey patch EmberApp.
+      let originalToTree = host.toTree.bind(host);
+      host.toTree = (...args) => {
+        return this.addTo(originalToTree(...args));
+      };
     }
 
     // We need to disable fingerprinting of chunks, because (1) they already

--- a/ts/bundle-config.ts
+++ b/ts/bundle-config.ts
@@ -9,12 +9,14 @@ const testsPattern = new RegExp(`^/?[^/]+/(tests|test-support)/`);
 // needs a given import will end up with that import.
 export const bundles = Object.freeze(['app', 'tests']);
 
-// Options we will pass to app.import when adding the bundle to the application.
-export function bundleOptions(name) {
-  if (name === 'tests') {
-    return { type: 'test' };
+// Which final JS file the given bundle's dependencies should go into.
+export function bundleEntrypoint(name) {
+  switch (name) {
+    case 'tests':
+      return 'assets/test-support.js';
+    case 'app':
+      return 'assets/vendor.js';
   }
-  return {};
 }
 
 // For any relative path to a module in our application, return which bundle its

--- a/ts/bundler.ts
+++ b/ts/bundler.ts
@@ -1,12 +1,12 @@
 import Plugin, { Tree } from 'broccoli-plugin';
 import makeDebug from 'debug';
-import { UnwatchedDir } from 'broccoli-source';
-import quickTemp from 'quick-temp';
 import WebpackBundler from './webpack';
 import Splitter, { BundleDependencies } from './splitter';
 import Package, { reloadDevPackages } from './package';
 import { merge } from 'lodash';
-import { bundles } from './bundle-config';
+import { bundles, bundleEntrypoint } from './bundle-config';
+import { join, dirname } from 'path';
+import { readFileSync, writeFileSync, ensureDirSync } from 'fs-extra';
 
 const debug = makeDebug('ember-auto-import:bundler');
 
@@ -17,19 +17,21 @@ export interface BundlerPluginOptions {
   packages: Set<Package>;
 }
 
-export interface BundlerHook {
-  build(modules: Map<string, BundleDependencies>): Promise<void>;
+export interface BuildResult {
+  entrypoints: Map<string, string[]>;
+  lazyAssets: string[];
 }
 
-class BundlerPlugin extends Plugin {
+export interface BundlerHook {
+  build(modules: Map<string, BundleDependencies>): Promise<BuildResult>;
+}
+
+export default class Bundler extends Plugin {
   private lastDeps = null;
   private cachedBundlerHook;
 
-  constructor(placeholderTree, private options : BundlerPluginOptions) {
-    // we need to have at least one valid input tree during
-    // construction, and our real trees aren't available yet, so we
-    // use a placeholder that doesn't really do anything.
-    super([placeholderTree], { persistentOutput: true });
+  constructor(allAppTree: Tree, private options : BundlerPluginOptions) {
+    super([allAppTree], { persistentOutput: true });
   }
 
   private get publicAssetURL() : string|undefined {
@@ -53,7 +55,7 @@ class BundlerPlugin extends Plugin {
       debug('extraWebpackConfig %j', extraWebpackConfig);
       this.cachedBundlerHook = new WebpackBundler(
         bundles,
-        this.outputPath,
+        join(this.outputPath, 'assets'),
         this.options.environment,
         extraWebpackConfig,
         this.options.consoleWrite,
@@ -68,25 +70,27 @@ class BundlerPlugin extends Plugin {
     let { splitter } = this.options;
     let bundleDeps = await splitter.deps();
     if (bundleDeps !== this.lastDeps) {
-      await this.bundlerHook.build(bundleDeps);
+      let buildResult = await this.bundlerHook.build(bundleDeps);
+      this.updateEntrypoints(buildResult.entrypoints);
+      this.addFastbootImports(buildResult.lazyAssets);
       this.lastDeps = bundleDeps;
     }
   }
-}
 
-export default class Bundler {
-  private placeholder: string;
-  private placeholderTree : Tree;
-  tree: Tree;
-
-  constructor(options: BundlerPluginOptions) {
-    quickTemp.makeOrRemake(this, 'placeholder', 'ember-auto-import');
-    this.placeholderTree = new UnwatchedDir(this.placeholder, { annotation: 'ember-auto-import' });
-    this.tree = new BundlerPlugin(this.placeholderTree, options);
+  private updateEntrypoints(entrypoints) {
+    for (let bundle of bundles) {
+      if (entrypoints.has(bundle)) {
+        let target = bundleEntrypoint(bundle);
+        let sources = entrypoints.get(bundle).map(asset => readFileSync(join(this.outputPath, 'assets', asset), 'utf8'));
+        sources.unshift(readFileSync(join(this.inputPaths[0], target), 'utf8'));
+        ensureDirSync(dirname(join(this.outputPath, target)));
+        writeFileSync(join(this.outputPath, target), sources.join("\n"), 'utf8');
+      }
+    }
   }
 
-  unsafeConnect(tree: Tree){
-    let plugin = this.tree as any;
-    plugin._inputNodes.push(tree);
+  private addFastbootImports(lazyAssets) {
+    let contents = lazyAssets.map(asset => readFileSync(join(this.outputPath, 'assets', asset), 'utf8'));
+    writeFileSync(join(this.outputPath, 'assets', 'auto-import-fastboot.js'), contents.join("\n"));
   }
 }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -29,24 +29,6 @@ module.exports = {
     }
   },
 
-  treeForVendor(tree) {
-    let autoImport = AutoImport.lookup(this);
-    if (autoImport.isPrimary(this)){
-      return autoImport.treeForVendor();
-    } else {
-      return tree;
-    }
-  },
-
-  treeForPublic(tree) {
-    let autoImport = AutoImport.lookup(this);
-    if (autoImport.isPrimary(this)){
-      return autoImport.treeForPublic();
-    } else {
-      return tree;
-    }
-  },
-
   updateFastBootManifest(manifest) {
     let autoImport = AutoImport.lookup(this);
     if (autoImport.isPrimary(this)) {

--- a/ts/webpack.ts
+++ b/ts/webpack.ts
@@ -2,11 +2,11 @@ import webpack from 'webpack';
 import { join } from 'path';
 import { merge } from 'lodash';
 import quickTemp from 'quick-temp';
-import { writeFileSync, readFileSync, readdirSync, emptyDirSync } from 'fs-extra';
+import { writeFileSync } from 'fs';
 import { compile, registerHelper } from 'handlebars';
 import jsStringEscape from 'js-string-escape';
 import { BundleDependencies } from './splitter';
-import { BundlerHook } from './bundler';
+import { BundlerHook, BuildResult } from './bundler';
 
 registerHelper('js-string-escape', jsStringEscape);
 
@@ -48,21 +48,18 @@ module.exports = (function(){
 export default class WebpackBundler implements BundlerHook {
   private stagingDir;
   private webpack;
-  private outputDir;
 
   constructor(bundles, outputDir, environment, extraWebpackConfig, private consoleWrite, private publicAssetURL){
     quickTemp.makeOrRemake(this, 'stagingDir', 'ember-auto-import-webpack');
     let entry = {};
     bundles.forEach(bundle => entry[bundle] = join(this.stagingDir, `${bundle}.js`));
 
-    this.outputDir = join(outputDir, 'ember-auto-import');
-
     let config = {
       mode: environment === 'production' ? 'production' : 'development',
       entry,
       output: {
-        path: join(this.outputDir, 'webpack-out'),
-        filename: `[id].js`,
+        path: outputDir,
+        filename: `chunk.[chunkhash].js`,
         chunkFilename: `chunk.[chunkhash].js`,
         libraryTarget: 'var',
         library: '__ember_auto_import__'
@@ -84,48 +81,26 @@ export default class WebpackBundler implements BundlerHook {
       this.writeEntryFile(bundle, deps);
     }
     let stats = await this.runWebpack();
-    let entryChunks = this.aggregateEntryChunks(stats);
-    this.aggregateLazyChunks(stats, entryChunks);
+    return this.summarizeStats(stats);
   }
 
-  // We're allowing webpack to split even our entrypoint Javascript into
-  // multiple chunks. That gives it the maximum flexibility to break shared
-  // things up between entrypoints. But in practice right now, our entrypoints
-  // are just "app" and "tests", and it's easier to just stick all the
-  // entrypoint chunks for each of those into the respective standard Ember
-  // Javascript files, which is in turn easier to do if we aggregate them here.
-  private aggregateEntryChunks(stats) {
-    let seen = new Set();
-    emptyDirSync(join(this.outputDir, 'entry'));
+  private summarizeStats(stats) : BuildResult {
+    let output = {
+      entrypoints: new Map(),
+      lazyAssets: []
+    };
+    let nonLazyAssets = new Set();
     for (let id of Object.keys(stats.entrypoints)) {
       let entrypoint = stats.entrypoints[id];
-      let chunks = entrypoint.chunks.map(chunkId => stats.chunks.find(c => c.id === chunkId));
-      chunks.sort(entryFirst);
-      let chunkContents = chunks.map(chunk => {
-        let filename = join(stats.outputPath, chunk.files[0]);
-        seen.add(chunk.files[0]);
-        return readFileSync(filename, 'utf8');
-      });
-      writeFileSync(join(this.outputDir, 'entry', `${id}.js`), chunkContents.join("\n"), 'utf8');
+      output.entrypoints.set(id, entrypoint.assets);
+      entrypoint.assets.forEach(asset => nonLazyAssets.add(asset));
     }
-    return seen;
-  }
-
-  // Lazy chunks are loaded normally in the browser app, just as webpack
-  // intends. But in Fastboot we load them all eagerly once when the server is
-  // starting up, which is easier to do if we have a file available that
-  // concatenates them all.
-  private aggregateLazyChunks(stats, entryChunks) {
-    let destDir = join(this.outputDir, 'lazy');
-    emptyDirSync(destDir);
-    let lazyChunks = readdirSync(stats.outputPath)
-      .filter(filename => !entryChunks.has(filename))
-      .map(filename => {
-        let contents = readFileSync(join(stats.outputPath, filename));
-        writeFileSync(join(destDir, filename), contents);
-        return contents;
-      });
-    writeFileSync(join(destDir, 'auto-import-fastboot.js'), lazyChunks.join("\n"));
+    for (let asset of stats.assets) {
+      if (!nonLazyAssets.has(asset.name)) {
+        output.lazyAssets.push(asset.name);
+      }
+    }
+    return output;
   }
 
   private writeEntryFile(name, deps){
@@ -157,14 +132,4 @@ export default class WebpackBundler implements BundlerHook {
     });
   }
 
-}
-
-function entryFirst(a, b){
-  if (a.entry === b.entry) {
-    return 0;
-  }
-  if (a.entry < b.entry) {
-    return 1;
-  }
-  return -1;
 }

--- a/ts/webpack.ts
+++ b/ts/webpack.ts
@@ -48,9 +48,11 @@ module.exports = (function(){
 export default class WebpackBundler implements BundlerHook {
   private stagingDir;
   private webpack;
+  private outputDir;
 
-  constructor(bundles, outputDir, environment, extraWebpackConfig, private consoleWrite, private publicAssetURL){
+  constructor(bundles, environment, extraWebpackConfig, private consoleWrite, private publicAssetURL){
     quickTemp.makeOrRemake(this, 'stagingDir', 'ember-auto-import-webpack');
+    quickTemp.makeOrRemake(this, 'outputDir', 'ember-auto-import-webpack');
     let entry = {};
     bundles.forEach(bundle => entry[bundle] = join(this.stagingDir, `${bundle}.js`));
 
@@ -58,7 +60,7 @@ export default class WebpackBundler implements BundlerHook {
       mode: environment === 'production' ? 'production' : 'development',
       entry,
       output: {
-        path: outputDir,
+        path: this.outputDir,
         filename: `chunk.[chunkhash].js`,
         chunkFilename: `chunk.[chunkhash].js`,
         libraryTarget: 'var',
@@ -87,7 +89,8 @@ export default class WebpackBundler implements BundlerHook {
   private summarizeStats(stats) : BuildResult {
     let output = {
       entrypoints: new Map(),
-      lazyAssets: []
+      lazyAssets: [],
+      dir: this.outputDir
     };
     let nonLazyAssets = new Set();
     for (let id of Object.keys(stats.entrypoints)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,6 +1450,13 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
+broccoli-merge-trees@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.0.tgz#90e4959f9e3c57cf1f04fab35152f3d849468d8b"
+  dependencies:
+    broccoli-plugin "^1.3.0"
+    merge-trees "^2.0.0"
+
 broccoli-middleware@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.2.1.tgz#a21f255f8bfe5a21c2f0fbf2417addd9d24c9436"
@@ -1883,6 +1890,10 @@ clean-css@^3.4.5:
   dependencies:
     commander "2.8.x"
     source-map "0.4.x"
+
+clean-up-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
 
 cli-cursor@^1.0.1:
   version "1.0.2"
@@ -3595,6 +3606,16 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
 
+fs-updater@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
+  dependencies:
+    can-symlink "^1.0.0"
+    clean-up-path "^1.0.0"
+    heimdalljs "^0.2.5"
+    heimdalljs-logger "^0.1.9"
+    rimraf "^2.6.2"
+
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz#b47df53493ef911df75731e70a9ded0189db40c9"
@@ -3897,7 +3918,7 @@ heimdalljs-logger@^0.1.7, heimdalljs-logger@^0.1.9:
     debug "^2.2.0"
     heimdalljs "^0.2.0"
 
-heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
+heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
   dependencies:
@@ -5141,6 +5162,13 @@ merge-trees@^1.0.1:
     heimdalljs-logger "^0.1.7"
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
+
+merge-trees@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
+  dependencies:
+    fs-updater "^1.0.4"
+    heimdalljs "^0.2.5"
 
 merge@^1.1.3:
   version "1.2.0"


### PR DESCRIPTION
ember-cli as of 3.4-beta has introduced changes that make it impossible for us to nicely emit the built dependencies via our own vendor and public trees, because it now considers those as *inputs* to the trees that we analyze, causing a circle.

This is, IMO, an architectural mistake in ember-cli, because there is no _real_ data dependency circle. Rather, the true data-dependency graph is being lost due to the way all trees are being combined and then re-separated to create the packager hook.

So anyway, now we must monkey patch EmberApp instead. It's pretty non-invasive and the function we are patching has been stable for a long long time.

Closes #26.