### PR TITLE
Smarter append

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,8 @@
 bower.json
 ember-cli-build.js
 testem.js
+/js/tests
+/ts/tests
 
 # ember-try
 .node_modules.ember-try/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,12 +5,6 @@
     "version": "0.2.0",
     "configurations": [
         {
-          "type": "node",
-          "request": "attach",
-          "name": "Attach",
-          "port": 9229
-        },
-        {
             "type": "node",
             "request": "launch",
             "name": "Build sample-direct",
@@ -64,6 +58,17 @@
             "args": [
                 "build"
             ]
-        }
+        },
+        {
+          "type": "node",
+          "request": "launch",
+          "name": "Run node tests",
+          "program": "${workspaceFolder}/node_modules/.bin/qunit",
+          "preLaunchTask": "tsc: build - tsconfig.json",
+          "args": [
+              "js/tests",
+              //"--filter", "passthrough file created"
+          ]
+      }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@types/fs-extra": "^5.0.4",
     "@types/lodash": "^4.14.110",
-    "@types/node": "^10.3.4",
+    "@types/node": "^10.7.1",
     "babel-eslint": "^8.2.5",
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "quick-temp": "^0.1.8",
     "resolve": "^1.7.1",
     "rimraf": "^2.6.2",
+    "source-map-url": "^0.4.0",
     "symlink-or-copy": "^1.2.0",
     "walk-sync": "^0.3.2",
     "webpack": "^4.12.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start": "ember serve",
     "test": "./scripts/test.sh",
     "test:root": "ember test --test-port=0",
+    "test:node": "qunit js/tests",
     "prepare": "./scripts/link-them.sh && yarn compile"
   },
   "dependencies": {
@@ -30,10 +31,7 @@
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-template": "^6.26.0",
     "babylon": "^6.18.0",
-    "broccoli-concat": "^3.2.2",
     "broccoli-debug": "^0.6.4",
-    "broccoli-funnel": "^2.0.1",
-    "broccoli-merge-trees": "^3.0.0",
     "broccoli-plugin": "^1.3.0",
     "debug": "^3.1.0",
     "ember-cli-babel": "^6.6.0",
@@ -57,7 +55,9 @@
     "@types/lodash": "^4.14.110",
     "@types/node": "^10.7.1",
     "babel-eslint": "^8.2.5",
+    "broccoli": "^1.1.4",
     "broccoli-asset-rev": "^2.4.5",
+    "broccoli-source": "^1.1.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.1.2",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -14,4 +14,5 @@ cd test-apps/sample-merged   && yarn test
 cd test-apps/sample-conflict && yarn test
 cd test-apps/sample-noconflict && yarn test
 yarn test:root
+yarn test:node
 EOF

--- a/ts/broccoli-append.ts
+++ b/ts/broccoli-append.ts
@@ -1,0 +1,175 @@
+import Plugin, { Tree } from 'broccoli-plugin';
+import { join } from 'path';
+import walkSync from 'walk-sync';
+import { unlinkSync, rmdirSync, mkdirSync, readFileSync, existsSync, writeFileSync, removeSync, readdirSync } from 'fs-extra';
+import FSTree from 'fs-tree-diff';
+import symlinkOrCopy from 'symlink-or-copy';
+import uniqBy from 'lodash/uniqBy';
+
+/*
+  This is a fairly specialized broccoli transform that we use to get the output
+  of our webpack build added to the ember app. Mostly it's needed because we're
+  forced to run quite late and use the postprocessTree hook, rather than nicely
+  emit our content as part of treeForVendor, etc, which would be easier but
+  doesn't work because of whack data dependencies in new versions of ember-cli's
+  broccoli graph.
+*/
+
+export interface AppendOptions {
+  // map from a directory in the appendedTree (like `entrypoints/app`) to a file
+  // that may exists in the upstreamTree (like `assets/vendor.js`). Appends the
+  // JS files in the directory to that file, when it exists.
+  mappings: Map<string, string>;
+
+  // map from a directory in the appendedTree (like `lazy`) to a directory where
+  // we will output those files in the output (like `assets`).
+  passthrough: Map<string, string>;
+}
+
+export default class Append extends Plugin {
+  private previousUpstreamTree = new FSTree();
+  private previousAppendedTree = new FSTree();
+  private mappings: Map<string, string>;
+  private reverseMappings: Map<string, string>;
+  private passthrough: Map<string, string>;
+
+  constructor(upstreamTree: Tree, appendedTree: Tree, options: AppendOptions) {
+    super([upstreamTree, appendedTree], {
+      annotation: 'ember-auto-import-analyzer',
+      persistentOutput: true
+    });
+
+    let reverseMappings = new Map();
+    for (let [key, value] of options.mappings.entries( )) {
+      reverseMappings.set(value, key);
+    }
+
+    this.mappings = options.mappings;
+    this.reverseMappings = reverseMappings;
+    this.passthrough = options.passthrough;
+  }
+
+  private get upstreamDir() {
+    return this.inputPaths[0];
+  }
+
+  private get appendedDir() {
+    return this.inputPaths[1];
+  }
+
+  // returns the set of output files that should change based on changes to the
+  // appendedTree.
+  private diffAppendedTree() {
+    let changed = new Set();
+    let { patchset, passthroughEntries } = this.appendedPatchset();
+    for (let [, relativePath] of patchset) {
+      let [first] = relativePath.split('/');
+      if (this.mappings.has(first)) {
+        changed.add(this.mappings.get(first));
+      }
+    }
+    return { needsUpdate: changed, passthroughEntries };
+  }
+
+  build() {
+    // First note which output files should change due to changes in the
+    // appendedTree
+    let { needsUpdate, passthroughEntries } = this.diffAppendedTree();
+
+    // Then process all changes in the upstreamTree
+    for (let [operation, relativePath, entry] of this.upstreamPatchset(passthroughEntries)) {
+      let outputPath = join(this.outputPath, relativePath);
+      switch (operation) {
+        case 'unlink':
+          unlinkSync(outputPath);
+          break;
+        case 'rmdir':
+          rmdirSync(outputPath);
+          break;
+        case 'mkdir':
+          mkdirSync(outputPath);
+          break;
+        case 'change':
+          removeSync(outputPath);
+          // deliberate fallthrough
+        case 'create':
+          if (this.reverseMappings.has(relativePath)) {
+            // this is where we see the upstream original file being created or
+            // modified. We should always generate the complete appended file here.
+            this.handleAppend(relativePath);
+            // it no longer needs update once we've handled it here
+            needsUpdate.delete(relativePath);
+          } else {
+            if (entry.isPassthrough) {
+              symlinkOrCopy.sync(join(this.appendedDir, entry.originalRelativePath), outputPath);
+            } else {
+              symlinkOrCopy.sync(join(this.upstreamDir, relativePath), outputPath);
+            }
+          }
+      }
+    }
+
+    // finally, any remaining things in `needsUpdate` are cases where the
+    // appendedTree changed but the corresponding file in the upstreamTree
+    // didn't. Those needs to get handled here.
+    for (let relativePath of needsUpdate.values()) {
+      this.handleAppend(relativePath);
+    }
+  }
+
+  private upstreamPatchset(passthroughEntries) {
+    let input = walkSync.entries(this.upstreamDir).concat(passthroughEntries);
+
+    // FSTree requires the entries to be sorted and uniq
+    input.sort((a,b) => a.relativePath.localeCompare(b.relativePath));
+    input = uniqBy(input, e => (e as any).relativePath);
+
+    let previous = this.previousUpstreamTree;
+    let next = (this.previousUpstreamTree = FSTree.fromEntries(input));
+    return previous.calculatePatch(next);
+  }
+
+  private appendedPatchset() {
+    let input = walkSync.entries(this.appendedDir);
+    let passthroughEntries = input
+      .map(e => {
+        let first = e.relativePath.split('/')[0];
+        let remapped = this.passthrough.get(first);
+        if (remapped) {
+          let o = Object.create(e);
+          o.relativePath = e.relativePath.replace(new RegExp('^' + first), remapped);
+          o.isPassthrough = true;
+          o.originalRelativePath = e.relativePath;
+          return o;
+        }
+      }).filter(Boolean);
+
+    let previous = this.previousAppendedTree;
+    let next = (this.previousAppendedTree = FSTree.fromEntries(input));
+    return { patchset: previous.calculatePatch(next), passthroughEntries };
+  }
+
+  private handleAppend(relativePath) {
+    let upstreamPath = join(this.upstreamDir, relativePath);
+    let outputPath = join(this.outputPath, relativePath);
+
+    if (!existsSync(upstreamPath)) {
+      removeSync(outputPath);
+      return;
+    }
+
+    let upstreamContent = readFileSync(upstreamPath, 'utf8');
+    let sourceDir = join(this.appendedDir, this.reverseMappings.get(relativePath));
+    let appendedContent;
+    if (existsSync(sourceDir)) {
+      appendedContent = readdirSync(sourceDir).map(name => {
+        if (/\.js$/.test(name)) {
+          return readFileSync(join(sourceDir, name), 'utf8');
+        }
+      }).filter(Boolean);
+    } else {
+      appendedContent = [];
+    }
+    writeFileSync(outputPath, [upstreamContent, ...appendedContent].join(";\n"));
+  }
+}

--- a/ts/bundle-config.ts
+++ b/ts/bundle-config.ts
@@ -12,11 +12,7 @@ export default class BundleConfig {
   // This list of valid bundles, in priority order. The first one in the list that
   // needs a given import will end up with that import.
   get names() : ReadonlyArray<string> {
-    if (this.emberApp.tests) {
-      return Object.freeze(['app', 'tests']);
-    } else {
-      return Object.freeze(['app']);
-    }
+    return Object.freeze(['app', 'tests']);
   }
 
   // Which final JS file the given bundle's dependencies should go into.

--- a/ts/tests/append-test.ts
+++ b/ts/tests/append-test.ts
@@ -169,13 +169,12 @@ Qmodule('broccoli-append', function(hooks) {
     outputFileSync(join(appended, 'app/2.js'), "two");
     await builder.build();
 
-    outputFileSync(join(appended, 'app/1.js'), "uno");
-
+    outputFileSync(join(appended, 'app/1.js'), "updated");
     await builder.build();
 
     let content = readFileSync(out, 'utf8');
     assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
-    assert.ok(/\buno\b/.test(content), 'found uno');
+    assert.ok(/\bupdated\b/.test(content), 'found updated');
     assert.ok(/\btwo\b/.test(content), 'found two');
   });
 
@@ -192,13 +191,13 @@ Qmodule('broccoli-append', function(hooks) {
     await builder.build();
 
     outputFileSync(join(upstream, 'assets/vendor.js'), "hola");
-    outputFileSync(join(appended, 'app/1.js'), "uno");
+    outputFileSync(join(appended, 'app/1.js'), "updated");
 
     await builder.build();
 
     let content = readFileSync(out, 'utf8');
     assert.ok(/^hola;\n/.test(content), 'original vendor.js and separator');
-    assert.ok(/\buno\b/.test(content), 'found uno');
+    assert.ok(/\bupdated\b/.test(content), 'found updated');
     assert.ok(/\btwo\b/.test(content), 'found two');
   });
 
@@ -289,10 +288,10 @@ Qmodule('broccoli-append', function(hooks) {
     outputFileSync(join(appended, 'lazy/1.js'), "one");
     await builder.build();
 
-    outputFileSync(join(appended, 'lazy/1.js'), "uno");
+    outputFileSync(join(appended, 'lazy/1.js'), "updated");
     await builder.build();
 
-    assert.equal(readFileSync(out, 'utf8'), 'uno');
+    assert.equal(readFileSync(out, 'utf8'), 'updated');
   });
 
   test('passthrough file deleted', async function(assert) {

--- a/ts/tests/append-test.ts
+++ b/ts/tests/append-test.ts
@@ -122,6 +122,20 @@ Qmodule('broccoli-append', function(hooks) {
     assert.ok(!/\bthree\b/.test(content), 'did not find three');
   });
 
+  test('moves trailing sourceMappingURL', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "function(){ console.log('hi'); } //# sourceMappingURL=vendor.map \n");
+    outputFileSync(join(appended, 'app/1.js'), "one");
+    await builder.build();
+    let content = readFileSync(out, 'utf8');
+    assert.equal(content, "function(){ console.log('hi'); } ;\none//# sourceMappingURL=vendor.map \n");
+  });
+
   test('upstream changed', async function(assert) {
     let mappings = new Map();
     mappings.set('app', 'assets/vendor.js');

--- a/ts/tests/append-test.ts
+++ b/ts/tests/append-test.ts
@@ -1,0 +1,320 @@
+// this rule doesn't understand .npmignore :-(
+// tslint:disable:no-implicit-dependencies
+import QUnit from 'qunit';
+import broccoli from 'broccoli';
+import { UnwatchedDir } from 'broccoli-source';
+// tslint:enable:no-implicit-dependencies
+
+import quickTemp from 'quick-temp';
+import { ensureDirSync, readFileSync, outputFileSync, removeSync, existsSync } from 'fs-extra';
+import { join } from 'path';
+import Append from '../broccoli-append';
+
+const { module: Qmodule, test } = QUnit;
+
+Qmodule('broccoli-append', function(hooks) {
+
+  let builder, upstream, appended;
+
+  hooks.beforeEach(function() {
+    quickTemp.makeOrRemake(this, 'workDir', 'auto-import-build-tests');
+    ensureDirSync(upstream = join(this.workDir, 'upstream'));
+    ensureDirSync(appended = join(this.workDir, 'appended'));
+  });
+
+  hooks.afterEach(function() {
+    removeSync(this.workDir);
+    if (builder) {
+      return builder.cleanup();
+    }
+  });
+
+  function makeBuilder(opts?) {
+    let node = new Append(new UnwatchedDir(upstream), new UnwatchedDir(appended), Object.assign({
+      mappings: new Map(),
+      passthrough: new Map()
+    }, opts));
+    return new broccoli.Builder(node);
+  }
+
+  test('non-matching file created', async function(assert) {
+    builder = makeBuilder();
+    await builder.build();
+    let out = join(builder.outputPath, 'assets/whatever');
+    outputFileSync(join(upstream, 'assets/whatever'), "hello");
+    await builder.build();
+    assert.equal(readFileSync(out, 'utf8'), 'hello');
+  });
+
+  test('non-matching file updated', async function(assert) {
+    builder = makeBuilder();
+    let out = join(builder.outputPath, 'assets/whatever');
+    outputFileSync(join(upstream, 'assets/whatever'), "hello");
+    await builder.build();
+    outputFileSync(join(upstream, 'assets/whatever'), "goodbye");
+    await builder.build();
+    assert.equal(readFileSync(out, 'utf8'), 'goodbye', 'updated value');
+  });
+
+  test('non-matching file deleted', async function(assert) {
+    builder = makeBuilder();
+    let out = join(builder.outputPath, 'assets/whatever');
+    outputFileSync(join(upstream, 'assets/whatever'), "hello");
+    await builder.build();
+    removeSync(join(upstream, 'assets/whatever'));
+    await builder.build();
+    assert.ok(!existsSync(out), 'removed');
+  });
+
+  test('nothing to be appended', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    ensureDirSync(join(appended, 'app'));
+    await builder.build();
+    assert.equal(readFileSync(out, 'utf8'), 'hello');
+  });
+
+  test('appended dir does not exist', async function(assert) {
+    let mappings = new Map();
+    mappings.set('other', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    await builder.build();
+    assert.equal(readFileSync(out, 'utf8'), 'hello');
+  });
+
+  test('nothing to append to', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(appended, 'app/chunk1.js'), "from-chunk-one");
+    await builder.build();
+    assert.ok(!existsSync(out), 'removed');
+  });
+
+  test('all files appended', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    outputFileSync(join(appended, 'app/1.js'), "one");
+    outputFileSync(join(appended, 'app/2.js'), "two");
+    outputFileSync(join(appended, 'tests/3.js'), "three");
+    await builder.build();
+    let content = readFileSync(out, 'utf8');
+    assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
+    assert.ok(/\bone\b/.test(content), 'found one');
+    assert.ok(/\btwo\b/.test(content), 'found two');
+    assert.ok(!/\bthree\b/.test(content), 'did not find three');
+  });
+
+  test('upstream changed', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    outputFileSync(join(appended, 'app/1.js'), "one");
+    outputFileSync(join(appended, 'app/2.js'), "two");
+    await builder.build();
+
+    outputFileSync(join(upstream, 'assets/vendor.js'), "bonjour");
+    await builder.build();
+
+    let content = readFileSync(out, 'utf8');
+    assert.ok(/^bonjour;\n/.test(content), 'original vendor.js and separator');
+    assert.ok(/\bone\b/.test(content), 'found one');
+    assert.ok(/\btwo\b/.test(content), 'found two');
+  });
+
+  test('appended changed', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    outputFileSync(join(appended, 'app/1.js'), "one");
+    outputFileSync(join(appended, 'app/2.js'), "two");
+    await builder.build();
+
+    outputFileSync(join(appended, 'app/1.js'), "uno");
+
+    await builder.build();
+
+    let content = readFileSync(out, 'utf8');
+    assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
+    assert.ok(/\buno\b/.test(content), 'found uno');
+    assert.ok(/\btwo\b/.test(content), 'found two');
+  });
+
+  test('upstream and appended changed', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    outputFileSync(join(appended, 'app/1.js'), "one");
+    outputFileSync(join(appended, 'app/2.js'), "two");
+    await builder.build();
+
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hola");
+    outputFileSync(join(appended, 'app/1.js'), "uno");
+
+    await builder.build();
+
+    let content = readFileSync(out, 'utf8');
+    assert.ok(/^hola;\n/.test(content), 'original vendor.js and separator');
+    assert.ok(/\buno\b/.test(content), 'found uno');
+    assert.ok(/\btwo\b/.test(content), 'found two');
+  });
+
+  test('additional appended file', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    outputFileSync(join(appended, 'app/1.js'), "one");
+    outputFileSync(join(appended, 'app/2.js'), "two");
+    await builder.build();
+
+    outputFileSync(join(appended, 'app/3.js'), "three");
+
+    await builder.build();
+
+    let content = readFileSync(out, 'utf8');
+    assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
+    assert.ok(/\bone\b/.test(content), 'found uno');
+    assert.ok(/\btwo\b/.test(content), 'found two');
+    assert.ok(/\bthree\b/.test(content), 'found three');
+  });
+
+  test('removed appended file', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    outputFileSync(join(appended, 'app/1.js'), "one");
+    outputFileSync(join(appended, 'app/2.js'), "two");
+    await builder.build();
+
+    removeSync(join(appended, 'app/1.js'));
+    await builder.build();
+
+    let content = readFileSync(out, 'utf8');
+    assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
+    assert.ok(!/\bone\b/.test(content), 'did not find one');
+    assert.ok(/\btwo\b/.test(content), 'found two');
+  });
+
+  test('removed upstream file', async function(assert) {
+    let mappings = new Map();
+    mappings.set('app', 'assets/vendor.js');
+    builder = makeBuilder({
+      mappings
+    });
+    let out = join(builder.outputPath, 'assets/vendor.js');
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    outputFileSync(join(appended, 'app/1.js'), "one");
+    outputFileSync(join(appended, 'app/2.js'), "two");
+    await builder.build();
+
+    removeSync(join(upstream, 'assets/vendor.js'));
+    await builder.build();
+
+    assert.ok(!existsSync(out), 'removed');
+  });
+
+  test('passthrough file created', async function(assert) {
+    let passthrough = new Map();
+    passthrough.set('lazy', 'assets');
+    builder = makeBuilder({
+      passthrough
+    });
+    let out = join(builder.outputPath, 'assets/1.js');
+    await builder.build();
+
+    outputFileSync(join(appended, 'lazy/1.js'), "one");
+    await builder.build();
+
+    assert.equal(readFileSync(out, 'utf8'), 'one');
+  });
+
+  test('passthrough file updated', async function(assert) {
+    let passthrough = new Map();
+    passthrough.set('lazy', 'assets');
+    builder = makeBuilder({
+      passthrough
+    });
+    let out = join(builder.outputPath, 'assets/1.js');
+    outputFileSync(join(appended, 'lazy/1.js'), "one");
+    await builder.build();
+
+    outputFileSync(join(appended, 'lazy/1.js'), "uno");
+    await builder.build();
+
+    assert.equal(readFileSync(out, 'utf8'), 'uno');
+  });
+
+  test('passthrough file deleted', async function(assert) {
+    let passthrough = new Map();
+    passthrough.set('lazy', 'assets');
+    builder = makeBuilder({
+      passthrough
+    });
+    let out = join(builder.outputPath, 'assets/1.js');
+    outputFileSync(join(appended, 'lazy/1.js'), "one");
+    await builder.build();
+
+    removeSync(join(appended, 'lazy/1.js'));
+    await builder.build();
+
+    assert.ok(!existsSync(out), 'removed');
+  });
+
+  test('appended and passthrough target same directory', async function(assert) {
+    let passthrough = new Map();
+    passthrough.set('lazy', 'assets');
+
+    let mappings = new Map();
+    mappings.set('app', 'assets');
+
+    builder = makeBuilder({
+      mappings,
+      passthrough
+    });
+
+    outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
+    outputFileSync(join(appended, 'lazy/1.js'), "one");
+
+    await builder.build();
+
+    assert.ok(existsSync(join(builder.outputPath, 'assets/vendor.js')), 'vendor.js');
+    assert.ok(existsSync(join(builder.outputPath, 'assets/1.js')), '1.js');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1450,13 +1450,6 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
-broccoli-merge-trees@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.0.tgz#90e4959f9e3c57cf1f04fab35152f3d849468d8b"
-  dependencies:
-    broccoli-plugin "^1.3.0"
-    merge-trees "^2.0.0"
-
 broccoli-middleware@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.2.1.tgz#a21f255f8bfe5a21c2f0fbf2417addd9d24c9436"
@@ -1464,7 +1457,7 @@ broccoli-middleware@^1.2.1:
     handlebars "^4.0.4"
     mime-types "^2.1.18"
 
-broccoli-node-info@^1.1.0:
+broccoli-node-info@1.1.0, broccoli-node-info@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-1.1.0.tgz#3aa2e31e07e5bdb516dd25214f7c45ba1c459412"
 
@@ -1503,6 +1496,10 @@ broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
     symlink-or-copy "^1.1.8"
+
+broccoli-slow-trees@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-slow-trees/-/broccoli-slow-trees-2.0.0.tgz#9741afe992787add64aec7f7c8211dfcc058278d"
 
 broccoli-slow-trees@^3.0.1:
   version "3.0.1"
@@ -1558,6 +1555,26 @@ broccoli-uglify-sourcemap@^2.1.1:
     terser "^3.7.5"
     walk-sync "^0.3.2"
     workerpool "^2.3.0"
+
+broccoli@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/broccoli/-/broccoli-1.1.4.tgz#b023b028b866f447ed14341007961efd03f7251c"
+  dependencies:
+    broccoli-node-info "1.1.0"
+    broccoli-slow-trees "2.0.0"
+    broccoli-source "^1.1.0"
+    commander "^2.5.0"
+    connect "^3.3.3"
+    copy-dereference "^1.0.0"
+    findup-sync "^1.0.0"
+    handlebars "^4.0.4"
+    heimdalljs-logger "^0.1.7"
+    mime "^1.2.11"
+    rimraf "^2.4.3"
+    rsvp "^3.5.0"
+    sane "^1.4.1"
+    tmp "0.0.31"
+    underscore.string "^3.2.2"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -1891,10 +1908,6 @@ clean-css@^3.4.5:
     commander "2.8.x"
     source-map "0.4.x"
 
-clean-up-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/clean-up-path/-/clean-up-path-1.0.0.tgz#de9e8196519912e749c9eaf67c13d64fac72a3e5"
-
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -2005,6 +2018,10 @@ commander@^2.12.1, commander@^2.6.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
+commander@^2.5.0:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+
 commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -2074,6 +2091,15 @@ configstore@^3.0.0:
     unique-string "^1.0.0"
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
+
+connect@^3.3.3:
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.6.6.tgz#09eff6c55af7236e137135a72574858b6786f524"
+  dependencies:
+    debug "2.6.9"
+    finalhandler "1.1.0"
+    parseurl "~1.3.2"
+    utils-merge "1.0.1"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -2372,6 +2398,12 @@ des.js@^1.0.0:
 destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
+
+detect-file@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-0.1.0.tgz#4935dedfd9488648e006b0129566e9386711ea63"
+  dependencies:
+    fs-exists-sync "^0.1.0"
 
 detect-file@^1.0.0:
   version "1.0.0"
@@ -2858,7 +2890,7 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
 
-encodeurl@~1.0.2:
+encodeurl@~1.0.1, encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
 
@@ -3179,6 +3211,12 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expand-tilde@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-1.2.2.tgz#0b81eba897e5a3d31d1c3d102f8f01441e559449"
+  dependencies:
+    os-homedir "^1.0.1"
+
 expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
@@ -3395,6 +3433,18 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
+finalhandler@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.0.tgz#ce0b6855b45853e791b2fcc680046d88253dd7f5"
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.2"
+    statuses "~1.3.1"
+    unpipe "~1.0.0"
+
 finalhandler@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.1.tgz#eebf4ed840079c83f4249038c9d703008301b105"
@@ -3447,6 +3497,15 @@ findup-sync@2.0.0:
     is-glob "^3.1.0"
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
+
+findup-sync@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-1.0.0.tgz#6f7e4b57b6ee3a4037b4414eaedea3f58f71e0ec"
+  dependencies:
+    detect-file "^0.1.0"
+    is-glob "^2.0.1"
+    micromatch "^2.3.7"
+    resolve-dir "^0.1.0"
 
 fireworm@^0.7.0:
   version "0.7.1"
@@ -3522,6 +3581,10 @@ from2@^2.1.0, from2@^2.1.1:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
+
+fs-exists-sync@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz#982d6893af918e72d08dec9e8673ff2b5a8d6add"
 
 fs-extra@^0.24.0:
   version "0.24.0"
@@ -3605,16 +3668,6 @@ fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5
     object-assign "^4.1.0"
     path-posix "^1.0.0"
     symlink-or-copy "^1.1.8"
-
-fs-updater@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/fs-updater/-/fs-updater-1.0.4.tgz#2329980f99ae9176e9a0e84f7637538a182ce63b"
-  dependencies:
-    can-symlink "^1.0.0"
-    clean-up-path "^1.0.0"
-    heimdalljs "^0.2.5"
-    heimdalljs-logger "^0.1.9"
-    rimraf "^2.6.2"
 
 fs-write-stream-atomic@^1.0.8:
   version "1.0.10"
@@ -3720,6 +3773,13 @@ glob@^7.0.3, glob@^7.0.4, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+global-modules@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-0.2.3.tgz#ea5a3bed42c6d6ce995a4f8a1269b5dae223828d"
+  dependencies:
+    global-prefix "^0.1.4"
+    is-windows "^0.2.0"
+
 global-modules@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
@@ -3727,6 +3787,15 @@ global-modules@^1.0.0:
     global-prefix "^1.0.1"
     is-windows "^1.0.1"
     resolve-dir "^1.0.0"
+
+global-prefix@^0.1.4:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-0.1.5.tgz#8d3bc6b8da3ca8112a160d8d496ff0462bfef78f"
+  dependencies:
+    homedir-polyfill "^1.0.0"
+    ini "^1.3.4"
+    is-windows "^0.2.0"
+    which "^1.2.12"
 
 global-prefix@^1.0.1:
   version "1.0.2"
@@ -3918,7 +3987,7 @@ heimdalljs-logger@^0.1.7, heimdalljs-logger@^0.1.9:
     debug "^2.2.0"
     heimdalljs "^0.2.0"
 
-heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3, heimdalljs@^0.2.5:
+heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/heimdalljs/-/heimdalljs-0.2.5.tgz#6aa54308eee793b642cff9cf94781445f37730ac"
   dependencies:
@@ -3939,7 +4008,7 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
-homedir-polyfill@^1.0.1:
+homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz#4c2bbc8a758998feebf5ed68580f76d46768b4bc"
   dependencies:
@@ -4350,6 +4419,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -5163,13 +5236,6 @@ merge-trees@^1.0.1:
     rimraf "^2.4.3"
     symlink-or-copy "^1.0.0"
 
-merge-trees@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/merge-trees/-/merge-trees-2.0.0.tgz#a560d796e566c5d9b2c40472a2967cca48d85161"
-  dependencies:
-    fs-updater "^1.0.4"
-    heimdalljs "^0.2.5"
-
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -5178,7 +5244,7 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^2.1.5:
+micromatch@^2.1.5, micromatch@^2.3.7:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
   dependencies:
@@ -5234,6 +5300,10 @@ mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.17, mime-types@~2.1.18:
 mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mime@^1.2.11:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -6292,6 +6362,13 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resolve-dir@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-0.1.1.tgz#b219259a5602fac5c5c496ad894a6e8cc430261e"
+  dependencies:
+    expand-tilde "^1.2.2"
+    global-modules "^0.2.3"
+
 resolve-dir@^1.0.0, resolve-dir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
@@ -6372,7 +6449,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3:
+rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
 
@@ -6431,6 +6508,18 @@ safe-regex@^1.1.0:
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+
+sane@^1.4.1:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-1.7.0.tgz#b3579bccb45c94cf20355cc81124990dfd346e30"
+  dependencies:
+    anymatch "^1.3.0"
+    exec-sh "^0.2.0"
+    fb-watchman "^2.0.0"
+    minimatch "^3.0.2"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+    watch "~0.10.0"
 
 sane@^2.2.0, sane@^2.4.1:
   version "2.5.2"
@@ -6814,6 +6903,10 @@ static-extend@^0.1.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
 
+statuses@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
+
 statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
@@ -7075,6 +7168,12 @@ tmp@0.0.28:
   dependencies:
     os-tmpdir "~1.0.1"
 
+tmp@0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 tmp@^0.0.29:
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
@@ -7269,7 +7368,7 @@ ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
 
-underscore.string@~3.3.4:
+underscore.string@^3.2.2, underscore.string@~3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
   dependencies:
@@ -7474,6 +7573,10 @@ watch-detector@^0.1.0:
     semver "^5.4.1"
     silent-error "^1.1.0"
 
+watch@~0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/watch/-/watch-0.10.0.tgz#77798b2da0f9910d595f1ace5b0c2258521f21dc"
+
 watch@~0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/watch/-/watch-0.18.0.tgz#28095476c6df7c90c963138990c0a5423eb4b986"
@@ -7565,7 +7668,7 @@ whatwg-url@^6.4.0, whatwg-url@^6.4.1:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
-which@^1.2.14, which@^1.2.9, which@^1.3.0:
+which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,9 +114,9 @@
   version "10.5.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.5.2.tgz#f19f05314d5421fe37e74153254201a7bf00a707"
 
-"@types/node@^10.3.4":
-  version "10.3.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.4.tgz#c74e8aec19e555df44609b8057311052a2c84d9e"
+"@types/node@^10.7.1":
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
 
 "@webassemblyjs/ast@1.5.12":
   version "1.5.12"


### PR DESCRIPTION
This deals with #105.

The goal here is to not need to predict which bundles exist in the app's build output. If a bundle exists and we have things to add to it, we will add them. If it doesn't, we don't worry about it. broccoli-concat cannot do that, or at least it cannot while maintaining the order invariants we need.

