### PR TITLE
Swap package.json keyword rollup -> webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "ember-addon",
     "import",
     "npm",
-    "rollup"
+    "webpack"
   ],
   "license": "MIT",
   "author": "Edward Faulkner <edward@eaf4.com>",


### PR DESCRIPTION
Extremely minor, but I noticed the release notes mentioned the implementation was changed in 0.2.0. I was just doing a peak under the hood to see if rollup was used anywhere and this seemed like the only leftover reference.