### PR TITLE
get `define` and `require` from scope w/o alerting webpack

### DIFF
--- a/ts/webpack.ts
+++ b/ts/webpack.ts
@@ -32,8 +32,8 @@ if (typeof document !== 'undefined') {
 
 module.exports = (function(){
   var w = window;
-  var d = w.define;
-  var r = w.require;
+  var d = eval('define');
+  var r = eval('require');
   w.emberAutoImportDynamic = function(specifier) {
     return r('_eai_dyn_' + specifier);
   };


### PR DESCRIPTION
Sometimes an ember app might need to close over the build app and vendor
files in order to hide any ember globals from the browser's global
scope. If you have a third-party script running that tries to use
`window.require` or `window.define` in a way that's incompatible with
ember's `loader.js` implementation, for instance.

In those cases, `window.define` won't be there unless another script has
defined it, and regardless, `ember-auto-import` is interested in the
values that ember defines.

Using `eval` here allows us to get the values defined in scope (by ember),
but also prevents webpack from noticing that we're using `define` and
`require`, which would send webpack its own behavioral path of resolving
things for the build. One of those few times when `eval` is your friend.