### PR TITLE
Strict CSP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Suported Options
 
  - `alias`: _object_, Map from package names to substitute packages that will be used instead.
  - `exclude`: _list of strings, defaults to []_. Packages in this list will be ignored by ember-auto-import. Can be helpful if the package is already included another way (like a shim from some other Ember addon).
+ - `forbidEval`: _boolean_, defaults to false. We use `eval` in development by default (because that is the fastest way to provide sourcemaps). If you need to comply with a strict Content Security Policy (CSP), you can set `forbidEval: true`. You will still get sourcemaps, they will just use a slower implementation.
  - `publicAssetURL`: where to load additional dynamic javascript files from. You usually don't need to set this -- the default works for any Ember app that isn't doing something unusual.
  - `webpack`: _object_, An object that will get merged into the configuration we pass to webpack. This lets you work around quirks in underlying libraries and otherwise customize the way Webpack will assemble your dependencies.
 
@@ -138,7 +139,7 @@ FAQ
 
 ###  I use Content Security Policy (CSP) and it breaks ember-auto-import.
 
-You need to either add "unsafe-eval" to your policy, or use [one of the suggestions for making webpack not require unsafe-eval](https://github.com/webpack/webpack/issues/5627).
+See `forbidEval` above.
 
 ### I'm trying to load a jQuery plugin, but it doesn't attach itself to the copy of jQuery that's already in my Ember app.
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,6 +6,7 @@ cd test-apps/sample-direct   && yarn test:fastboot
 cd test-apps/sample-direct   && yarn test:prod
 cd test-apps/sample-direct   && yarn test:custom-bundles
 cd test-apps/sample-direct   && yarn test:custom-bundles-fastboot
+cd test-apps/sample-direct   && yarn test:custom-csp
 cd test-apps/sample-indirect && yarn test
 cd test-apps/sample-indirect && yarn test:fastboot
 cd test-apps/sample-addon    && yarn test

--- a/test-apps/sample-direct/ember-cli-build.js
+++ b/test-apps/sample-direct/ember-cli-build.js
@@ -23,6 +23,10 @@ module.exports = function(defaults) {
     };
   }
 
+  if (process.env.CUSTOMIZE_CSP) {
+    options.autoImport.forbidEval = true;
+  }
+
   let app = new EmberApp(defaults, options);
 
   // Use `app.import` to add additional libraries to the generated

--- a/test-apps/sample-direct/lib/csp-switcher/index.js
+++ b/test-apps/sample-direct/lib/csp-switcher/index.js
@@ -1,0 +1,17 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = {
+  name: 'csp-switcher',
+
+  isDevelopingAddon() {
+    return true;
+  },
+
+  contentFor(which) {
+    if (which === 'head' && process.env.CUSTOMIZE_CSP) {
+      return `<meta http-equiv="Content-Security-Policy" content="default-src 'self';"></meta>`
+    }
+  }
+};
+

--- a/test-apps/sample-direct/lib/csp-switcher/package.json
+++ b/test-apps/sample-direct/lib/csp-switcher/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "csp-switcher",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/test-apps/sample-direct/package.json
+++ b/test-apps/sample-direct/package.json
@@ -16,6 +16,7 @@
     "start": "ember serve",
     "test": "ember test --test-port=0",
     "test:custom-bundles": "if [ ${EAI_SCENARIO:-none} != 2.18 ]; then CUSTOMIZE_BUNDLES=true ember test --test-port=0; fi",
+    "test:custom-csp": "CUSTOMIZE_CSP=true ember test --test-port=0",
     "test:fastboot": "qunit fastboot-tests/dev-fastboot-test.js",
     "test:custom-bundles-fastboot": "if [ ${EAI_SCENARIO:-none} != 2.18 ]; then CUSTOMIZE_BUNDLES=true qunit fastboot-tests/dev-fastboot-test.js; fi",
     "test:prod": "qunit fastboot-tests/prod-fastboot-test.js"
@@ -59,7 +60,8 @@
   },
   "ember-addon": {
     "paths": [
-      "lib/bundle-switcher"
+      "lib/bundle-switcher",
+      "lib/csp-switcher"
     ]
   }
 }

--- a/ts/bundler.ts
+++ b/ts/bundler.ts
@@ -65,6 +65,9 @@ export default class Bundler extends Plugin {
         {},
         ...[...this.options.packages.values()].map(pkg => pkg.webpackConfig)
       );
+      if ([...this.options.packages.values()].find(pkg => pkg.forbidsEval)) {
+        extraWebpackConfig.devtool = 'source-map';
+      }
       debug('extraWebpackConfig %j', extraWebpackConfig);
       this.cachedBundlerHook = new WebpackBundler(
         this.options.bundles,

--- a/ts/package.ts
+++ b/ts/package.ts
@@ -149,4 +149,10 @@ export default class Package {
   get publicAssetURL(): string | undefined {
     return this.autoImportOptions && this.autoImportOptions.publicAssetURL;
   }
+
+  get forbidsEval(): boolean {
+    // only apps (not addons) are allowed to set this, because it's motivated by
+    // the apps own Content Security Policy.
+    return !this.isAddon && this.autoImportOptions && this.autoImportOptions.forbidEval;
+  }
 }

--- a/ts/webpack.ts
+++ b/ts/webpack.ts
@@ -79,7 +79,7 @@ export default class WebpackBundler implements BundlerHook {
         splitChunks: {
           chunks: 'all'
         }
-      }
+      },
     };
     if (extraWebpackConfig) {
       merge(config, extraWebpackConfig);


### PR DESCRIPTION
Closes #50.

This provides a first-class option for supporting strict Content Security Policies that forbid `eval`, and it ensures that we are running tests in that mode so we don't accidentally slip in a dependency on `eval` in the future.