### PR TITLE
Fix missing rebuild content

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -73,7 +73,7 @@
           "request": "launch",
           "name": "Run node tests",
           "program": "${workspaceFolder}/node_modules/.bin/qunit",
-          "preLaunchTask": "tsc: build - tsconfig.json",
+          "cwd": "${workspaceFolder}/packages/ember-auto-import",
           "args": [
               "js/tests",
               //"--filter", "passthrough file created"


### PR DESCRIPTION
This fixes #166. We had test coverage that tries to cover this case but the test used simpler paths than the real build.