### PR TITLE
chore: add `yarn-error.log` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ packages/*/node_modules
 packages/*/tmp
 packages/*/dist
 node_modules
+yarn-error.log


### PR DESCRIPTION
As per #180.