### PR TITLE
Bundle CSS files

### DIFF
--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -78,8 +78,12 @@ export default class AutoImport {
 
     let mappings = new Map();
     for (let name of this.bundles.names) {
-      let target = this.bundles.bundleEntrypoint(name);
-      mappings.set(`entrypoints/${name}`, target);
+      let byType = new Map();
+      mappings.set(`entrypoints/${name}`, byType);
+      for (let type of this.bundles.types) {
+        let target = this.bundles.bundleEntrypoint(name, type);
+        byType.set(type, target);
+      }
     }
 
     let passthrough = new Map();

--- a/packages/ember-auto-import/ts/broccoli-append.ts
+++ b/packages/ember-auto-import/ts/broccoli-append.ts
@@ -209,7 +209,7 @@ interface PassthroughEntry extends WalkSyncEntry {
 
 type AugmentedWalkSyncEntry = WalkSyncEntry | PassthroughEntry;
 
-function findByPrefix(path: string, map: Map<string, any>) {
+function findByPrefix<T>(path: string, map: Map<string, T>) {
   let parts = path.split('/');
   for (let i = 1; i < parts.length; i++) {
     let candidate = parts.slice(0, i).join('/');

--- a/packages/ember-auto-import/ts/bundle-config.ts
+++ b/packages/ember-auto-import/ts/bundle-config.ts
@@ -15,13 +15,27 @@ export default class BundleConfig {
     return Object.freeze(['app', 'tests']);
   }
 
+  get types(): ReadonlyArray<string> {
+    return Object.freeze(['js', 'css']);
+  }
+
   // Which final JS file the given bundle's dependencies should go into.
-  bundleEntrypoint(name: string): string | undefined {
+  bundleEntrypoint(name: string, type: string): string | undefined {
     switch (name) {
       case 'tests':
-        return 'assets/test-support.js';
+        switch (type) {
+          case 'js':
+            return 'assets/test-support.js';
+          case 'css':
+            return 'assets/test-support.css';
+        }
       case 'app':
-        return this.emberApp.options.outputPaths.vendor.js.replace(/^\//, '');
+        switch (type) {
+          case 'js':
+            return this.emberApp.options.outputPaths.vendor.js.replace(/^\//, '');
+          case 'css':
+            return this.emberApp.options.outputPaths.vendor.css.replace(/^\//, '');
+        }
     }
   }
 
@@ -36,6 +50,6 @@ export default class BundleConfig {
   }
 
   get lazyChunkPath() {
-    return dirname(this.bundleEntrypoint(this.names[0])!);
+    return dirname(this.bundleEntrypoint(this.names[0], 'js')!);
   }
 }

--- a/packages/ember-auto-import/ts/tests/append-test.ts
+++ b/packages/ember-auto-import/ts/tests/append-test.ts
@@ -66,7 +66,9 @@ Qmodule('broccoli-append', function(hooks) {
 
   test('nothing to be appended', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
     builder = makeBuilder({
       mappings
     });
@@ -79,7 +81,9 @@ Qmodule('broccoli-append', function(hooks) {
 
   test('appended dir does not exist', async function(assert) {
     let mappings = new Map();
-    mappings.set('other', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('other', byType);
+    byType.set('js', 'assets/vendor.js');
     builder = makeBuilder({
       mappings
     });
@@ -91,7 +95,9 @@ Qmodule('broccoli-append', function(hooks) {
 
   test('nothing to append to', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
     builder = makeBuilder({
       mappings
     });
@@ -103,26 +109,48 @@ Qmodule('broccoli-append', function(hooks) {
 
   test('all files appended', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
+    byType.set('css', 'assets/vendor.css');
     builder = makeBuilder({
       mappings
     });
-    let out = join(builder.outputPath, 'assets/vendor.js');
+
+    let outJs = join(builder.outputPath, 'assets/vendor.js');
     outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
     outputFileSync(join(appended, 'app/1.js'), "one");
     outputFileSync(join(appended, 'app/2.js'), "two");
     outputFileSync(join(appended, 'tests/3.js'), "three");
+
+    let outCss = join(builder.outputPath, 'assets/vendor.css');
+    outputFileSync(join(upstream, 'assets/vendor.css'), "hola");
+    outputFileSync(join(appended, 'app/1.css'), "uno");
+    outputFileSync(join(appended, 'app/2.css'), "dos");
+    outputFileSync(join(appended, 'tests/3.css'), "tres");
+
     await builder.build();
-    let content = readFileSync(out, 'utf8');
+
+    let content = readFileSync(outJs, 'utf8');
     assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
     assert.ok(/\bone\b/.test(content), 'found one');
     assert.ok(/\btwo\b/.test(content), 'found two');
     assert.ok(!/\bthree\b/.test(content), 'did not find three');
+    assert.ok(!/\buno\b/.test(content), 'did not find CSS');
+
+    content = readFileSync(outCss, 'utf8');
+    assert.ok(/^hola;\n/.test(content), 'original vendor.css and separator');
+    assert.ok(/\buno\b/.test(content), 'found uno');
+    assert.ok(/\bdos\b/.test(content), 'found dos');
+    assert.ok(!/\btres\b/.test(content), 'did not find tres');
+    assert.ok(!/\bone\b/.test(content), 'did not find JS');
   });
 
   test('moves trailing sourceMappingURL', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
     builder = makeBuilder({
       mappings
     });
@@ -136,7 +164,9 @@ Qmodule('broccoli-append', function(hooks) {
 
   test('does not match non-trailing sourceMappingURL', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
     builder = makeBuilder({
       mappings
     });
@@ -150,28 +180,49 @@ Qmodule('broccoli-append', function(hooks) {
 
   test('upstream changed', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
+    byType.set('css', 'assets/vendor.css');
     builder = makeBuilder({
       mappings
     });
-    let out = join(builder.outputPath, 'assets/vendor.js');
+
+    let outJs = join(builder.outputPath, 'assets/vendor.js');
     outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
     outputFileSync(join(appended, 'app/1.js'), "one");
     outputFileSync(join(appended, 'app/2.js'), "two");
+
+    let outCss = join(builder.outputPath, 'assets/vendor.css');
+    outputFileSync(join(upstream, 'assets/vendor.css'), "hola");
+    outputFileSync(join(appended, 'app/1.css'), "uno");
+    outputFileSync(join(appended, 'app/2.css'), "dos");
+
     await builder.build();
 
     outputFileSync(join(upstream, 'assets/vendor.js'), "bonjour");
+    outputFileSync(join(upstream, 'assets/vendor.css'), "gutentag");
+
     await builder.build();
 
-    let content = readFileSync(out, 'utf8');
+    let content = readFileSync(outJs, 'utf8');
     assert.ok(/^bonjour;\n/.test(content), 'original vendor.js and separator');
     assert.ok(/\bone\b/.test(content), 'found one');
     assert.ok(/\btwo\b/.test(content), 'found two');
+    assert.ok(!/\buno\b/.test(content), 'did not find CSS');
+
+    content = readFileSync(outCss, 'utf8');
+    assert.ok(/^gutentag;\n/.test(content), 'original vendor.css and separator');
+    assert.ok(/\buno\b/.test(content), 'found uno');
+    assert.ok(/\bdos\b/.test(content), 'found dos');
+    assert.ok(!/\bone\b/.test(content), 'did not find JS');
   });
 
   test('inner appended changed', async function(assert) {
     let mappings = new Map();
-    mappings.set('app/inner', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app/inner', byType);
+    byType.set('js', 'assets/vendor.js');
     builder = makeBuilder({
       mappings
     });
@@ -192,108 +243,189 @@ Qmodule('broccoli-append', function(hooks) {
 
   test('appended changed', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
+    byType.set('css', 'assets/vendor.css');
     builder = makeBuilder({
       mappings
     });
-    let out = join(builder.outputPath, 'assets/vendor.js');
+
+    let outJs = join(builder.outputPath, 'assets/vendor.js');
     outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
     outputFileSync(join(appended, 'app/1.js'), "one");
     outputFileSync(join(appended, 'app/2.js'), "two");
+
+    let outCss = join(builder.outputPath, 'assets/vendor.css');
+    outputFileSync(join(upstream, 'assets/vendor.css'), "hola");
+    outputFileSync(join(appended, 'app/1.css'), "uno");
+    outputFileSync(join(appended, 'app/2.css'), "dos");
+
     await builder.build();
 
     outputFileSync(join(appended, 'app/1.js'), "updated");
+    outputFileSync(join(appended, 'app/1.css'), "modified");
+
     await builder.build();
 
-    let content = readFileSync(out, 'utf8');
+    let content = readFileSync(outJs, 'utf8');
     assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
     assert.ok(/\bupdated\b/.test(content), 'found updated');
     assert.ok(/\btwo\b/.test(content), 'found two');
+
+    content = readFileSync(outCss, 'utf8');
+    assert.ok(/^hola;\n/.test(content), 'original vendor.css and separator');
+    assert.ok(/\bmodified\b/.test(content), 'found modified');
+    assert.ok(/\bdos\b/.test(content), 'found dos');
   });
 
   test('upstream and appended changed', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
+    byType.set('css', 'assets/vendor.css');
     builder = makeBuilder({
       mappings
     });
-    let out = join(builder.outputPath, 'assets/vendor.js');
+
+    let outJs = join(builder.outputPath, 'assets/vendor.js');
     outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
     outputFileSync(join(appended, 'app/1.js'), "one");
     outputFileSync(join(appended, 'app/2.js'), "two");
+
+    let outCss = join(builder.outputPath, 'assets/vendor.css');
+    outputFileSync(join(upstream, 'assets/vendor.css'), "hola");
+    outputFileSync(join(appended, 'app/1.css'), "uno");
+    outputFileSync(join(appended, 'app/2.css'), "dos");
+
     await builder.build();
 
-    outputFileSync(join(upstream, 'assets/vendor.js'), "hola");
+    outputFileSync(join(upstream, 'assets/vendor.js'), "bonjour");
     outputFileSync(join(appended, 'app/1.js'), "updated");
+    outputFileSync(join(upstream, 'assets/vendor.css'), "guten tag");
+    outputFileSync(join(appended, 'app/1.css'), "modified");
 
     await builder.build();
 
-    let content = readFileSync(out, 'utf8');
-    assert.ok(/^hola;\n/.test(content), 'original vendor.js and separator');
+    let content = readFileSync(outJs, 'utf8');
+    assert.ok(/^bonjour;\n/.test(content), 'original vendor.js and separator');
     assert.ok(/\bupdated\b/.test(content), 'found updated');
     assert.ok(/\btwo\b/.test(content), 'found two');
+
+    content = readFileSync(outCss, 'utf8');
+    assert.ok(/^guten tag;\n/.test(content), 'original vendor.css and separator');
+    assert.ok(/\bmodified\b/.test(content), 'found modified');
+    assert.ok(/\bdos\b/.test(content), 'found dos');
   });
 
   test('additional appended file', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
+    byType.set('css', 'assets/vendor.css');
     builder = makeBuilder({
       mappings
     });
-    let out = join(builder.outputPath, 'assets/vendor.js');
+
+    let outJs = join(builder.outputPath, 'assets/vendor.js');
     outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
     outputFileSync(join(appended, 'app/1.js'), "one");
     outputFileSync(join(appended, 'app/2.js'), "two");
+
+    let outCss = join(builder.outputPath, 'assets/vendor.css');
+    outputFileSync(join(upstream, 'assets/vendor.css'), "hola");
+    outputFileSync(join(appended, 'app/1.css'), "uno");
+    outputFileSync(join(appended, 'app/2.css'), "dos");
+
     await builder.build();
 
     outputFileSync(join(appended, 'app/3.js'), "three");
+    outputFileSync(join(appended, 'app/3.css'), "tres");
 
     await builder.build();
 
-    let content = readFileSync(out, 'utf8');
+    let content = readFileSync(outJs, 'utf8');
     assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
     assert.ok(/\bone\b/.test(content), 'found uno');
     assert.ok(/\btwo\b/.test(content), 'found two');
     assert.ok(/\bthree\b/.test(content), 'found three');
+
+    content = readFileSync(outCss, 'utf8');
+    assert.ok(/^hola;\n/.test(content), 'original vendor.css and separator');
+    assert.ok(/\buno\b/.test(content), 'found uno');
+    assert.ok(/\bdos\b/.test(content), 'found dos');
+    assert.ok(/\btres\b/.test(content), 'found tres');
   });
 
   test('removed appended file', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
+    byType.set('css', 'assets/vendor.css');
     builder = makeBuilder({
       mappings
     });
-    let out = join(builder.outputPath, 'assets/vendor.js');
+
+    let outJs = join(builder.outputPath, 'assets/vendor.js');
     outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
     outputFileSync(join(appended, 'app/1.js'), "one");
     outputFileSync(join(appended, 'app/2.js'), "two");
+
+    let outCss = join(builder.outputPath, 'assets/vendor.css');
+    outputFileSync(join(upstream, 'assets/vendor.css'), "hola");
+    outputFileSync(join(appended, 'app/1.css'), "uno");
+    outputFileSync(join(appended, 'app/2.css'), "dos");
+
     await builder.build();
 
     removeSync(join(appended, 'app/1.js'));
+    removeSync(join(appended, 'app/1.css'));
+
     await builder.build();
 
-    let content = readFileSync(out, 'utf8');
+    let content = readFileSync(outJs, 'utf8');
     assert.ok(/^hello;\n/.test(content), 'original vendor.js and separator');
     assert.ok(!/\bone\b/.test(content), 'did not find one');
     assert.ok(/\btwo\b/.test(content), 'found two');
+
+    content = readFileSync(outCss, 'utf8');
+    assert.ok(/^hola;\n/.test(content), 'original vendor.css and separator');
+    assert.ok(!/\buno\b/.test(content), 'did not find uno');
+    assert.ok(/\bdos\b/.test(content), 'found dos');
   });
 
   test('removed upstream file', async function(assert) {
     let mappings = new Map();
-    mappings.set('app', 'assets/vendor.js');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets/vendor.js');
+    byType.set('css', 'assets/vendor.css');
     builder = makeBuilder({
       mappings
     });
-    let out = join(builder.outputPath, 'assets/vendor.js');
+
+    let outJs = join(builder.outputPath, 'assets/vendor.js');
     outputFileSync(join(upstream, 'assets/vendor.js'), "hello");
     outputFileSync(join(appended, 'app/1.js'), "one");
     outputFileSync(join(appended, 'app/2.js'), "two");
+
+    let outCss = join(builder.outputPath, 'assets/vendor.css');
+    outputFileSync(join(upstream, 'assets/vendor.css'), "hola");
+    outputFileSync(join(appended, 'app/1.css'), "uno");
+    outputFileSync(join(appended, 'app/2.css'), "dos");
+
     await builder.build();
 
     removeSync(join(upstream, 'assets/vendor.js'));
+    removeSync(join(upstream, 'assets/vendor.css'));
+
     await builder.build();
 
-    assert.ok(!existsSync(out), 'removed');
+    assert.ok(!existsSync(outJs), 'removed js');
+    assert.ok(!existsSync(outCss), 'removed css');
   });
 
   test('passthrough file created', async function(assert) {
@@ -364,7 +496,9 @@ Qmodule('broccoli-append', function(hooks) {
     passthrough.set('lazy', 'assets');
 
     let mappings = new Map();
-    mappings.set('app', 'assets');
+    let byType = new Map();
+    mappings.set('app', byType);
+    byType.set('js', 'assets');
 
     builder = makeBuilder({
       mappings,


### PR DESCRIPTION
I took a stab at the most basic level of support for CSS. These changes make `ember-auto-import` bundle any CSS found in the webpack output, so by specifying a webpack config that collects CSS, e.g. [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin), we can include CSS in Ember's vendor.css.

My personal use case is integrating CKEditor5 into my build. Rather than using one of their pre-built packages, I want to build/customize my own, and consume their source packages using `ember-auto-import` to mimic the [webpack build](https://github.com/ckeditor/ckeditor5-build-inline/blob/master/webpack.config.js) they use to generate the pre-built packages. It appears to work seamlessly for the Javascript, but I need to do something like [this](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/advanced-setup.html#option-extracting-css) to get the CSS, which motivated this PR.

A few notes about this PR:

1. I've not spent much time in `ember-auto-import`'s code, so please let me know if this isn't the right approach.
2. I wonder if bundling CSS should be opt-in via a config? I like opt-in, but I think the only way to get CSS into `ember-auto-import`'s tree is by customizing the webpack config to do so, so maybe that's opt-in enough?
3. In the unit tests, I wasn't quite sure how many tests should include CSS files -- all of them seemed overkill since CSS and JS share the same code path (just with different values). So please let me know if you think I added CSS testing to too many or too few tests!