### PR TITLE
[DOC] Add dynamic import from addon instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ Using ember-auto-import inside an addon is almost exactly the same as inside an 
       this._super.included.apply(this, arguments);
     }
     ```
+ - if your addon uses [Dynamic Import](#dynamic-import), it is [required](https://github.com/babel/ember-cli-babel#options) that you
+   register the babel plugin in your `index.js` instead of `ember-cli-build.js`:
+    ```js
+    // index.js
+    module.exports = {
+      options: {
+        babel: {
+          plugins: [ require.resolve('ember-auto-import/babel-plugin') ]
+        }
+      }
+    };
+    ```
 FAQ
 ---
 


### PR DESCRIPTION
Ember-cli-babel has the process for registering babel plugins worked out
for addons, adding a quick note here will save some pain in tracking
that information down.

Fixes #254