### PR TITLE
optional output fastboot files

### DIFF
--- a/packages/ember-auto-import/ts/bundler.ts
+++ b/packages/ember-auto-import/ts/bundler.ts
@@ -148,9 +148,11 @@ export default class Bundler extends Plugin {
         }
       })
       .filter(Boolean);
-    writeFileSync(
-      join(this.outputPath, 'lazy', 'auto-import-fastboot.js'),
-      contents.join('\n')
-    );
+    if (this.rootPackage.isFastBootEnabled) {
+      writeFileSync(
+        join(this.outputPath, 'lazy', 'auto-import-fastboot.js'),
+        contents.join('\n')
+      );
+    }
   }
 }

--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -1,6 +1,7 @@
 import resolve from 'resolve';
 import { join } from 'path';
 import { readFileSync } from 'fs';
+import { Memoize } from 'typescript-memoize';
 import { Configuration } from 'webpack';
 
 const cache: WeakMap<any, Package> = new WeakMap();
@@ -81,6 +82,14 @@ export default class Package {
   get babelMajorVersion() {
     this._ensureBabelDetails();
     return this._babelMajorVersion;
+  }
+
+  @Memoize()
+  get isFastBootEnabled() {
+    return process.env.FASTBOOT_DISABLED !== 'true'
+    && !!this._parent.addons.find(
+      (addon: any) => addon.name === 'ember-cli-fastboot'
+    );
   }
 
   private buildBabelOptions(instance: any, options: any) {


### PR DESCRIPTION
@ef4 

there are many chunk files in my project, so auto-import-fastboot file size is too large .
if we never use fastboot , so ignore fastboot is better . 

related issue: https://github.com/ef4/ember-auto-import/issues/150

