### PR TITLE
Update node version to 12.x (latest LTS)

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js 8.x
+    - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
-        node-version: 8.x
+        node-version: 12.x
     - name: pick version and install
       run: ./scripts/change-ember-cli-version.sh
       env:


### PR DESCRIPTION
Fixes the following CI error:
> error npm-package-arg@8.0.1: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.17.0"

https://github.com/ef4/ember-auto-import/pull/271/checks?check_run_id=518716456