### PR TITLE
Update regex to work with scoped npm packages

### DIFF
--- a/packages/ember-auto-import/ts/bundle-config.ts
+++ b/packages/ember-auto-import/ts/bundle-config.ts
@@ -4,7 +4,7 @@
 */
 
 import { dirname } from 'path';
-const testsPattern = new RegExp(`^/?[^/]+/(tests|test-support)/`);
+const testsPattern = new RegExp(`^(@[^/]+)?/?[^/]+/(tests|test-support)/`);
 
 export default class BundleConfig {
   constructor(private emberApp: any) {}


### PR DESCRIPTION
Towards https://github.com/ef4/ember-auto-import/issues/284

This regex is used to detect if an import is referencing the tests or addon-test-support folders.

As it stands it will match `my-package/test-support` but not `@scoped/my-package/test-support` which seems like an oversight.

I honestly don't fully understand the potential downstream consequences of this or how to test it, but it seems like a fairly uncontroversial fix. I took a look at the tests and they're a little hard to follow, (which is understandable given the nature of this library), happy to add one if you can point me in the right direction.