### PR TITLE
Fix merging addon webpack configs

### DIFF
--- a/packages/ember-auto-import/ts/bundler.ts
+++ b/packages/ember-auto-import/ts/bundler.ts
@@ -3,7 +3,7 @@ import makeDebug from 'debug';
 import WebpackBundler from './webpack';
 import Splitter, { BundleDependencies } from './splitter';
 import Package, { reloadDevPackages, Options } from './package';
-import { merge } from 'lodash';
+import { mergeWith } from 'lodash';
 import { join } from 'path';
 import { readFileSync, writeFileSync, emptyDirSync, copySync } from 'fs-extra';
 import BundleConfig from './bundle-config';
@@ -74,9 +74,16 @@ export default class Bundler extends Plugin {
 
   get bundlerHook(): BundlerHook {
     if (!this.cachedBundlerHook) {
-      let extraWebpackConfig = merge(
+      let extraWebpackConfig = mergeWith(
         {},
         ...[...this.options.packages.values()].map(pkg => pkg.webpackConfig)
+        ,
+        (objValue: any, srcValue: any) => {
+          // arrays concat
+          if (Array.isArray(objValue)) {
+            return objValue.concat(srcValue);
+          }
+        }
       );
       if ([...this.options.packages.values()].find(pkg => pkg.forbidsEval)) {
         extraWebpackConfig.devtool = 'source-map';


### PR DESCRIPTION
Like we do [here](https://github.com/ef4/ember-auto-import/blob/ab4cc5614bfb7b56e0649de917b3de8bc073461f/packages/ember-auto-import/ts/webpack.ts#L229-L242), we need to concatenate arrays here or addons and apps will overwrite each other's array configurations.

I'm not sure how best to write a test for this change, and would love some advice.