### PR TITLE
Infer bundle type (app vs test) by original tree if known.

### DIFF
--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -1,6 +1,7 @@
 import Splitter from './splitter';
 import Bundler from './bundler';
 import Analyzer from './analyzer';
+import type { TreeType } from './analyzer';
 import Package from './package';
 import { buildDebugCallback } from 'broccoli-debug';
 import BundleConfig from './bundle-config';
@@ -16,7 +17,7 @@ const debugTree = buildDebugCallback('ember-auto-import');
 // what you're doing.
 export interface AutoImportSharedAPI {
   isPrimary(addonInstance: AddonInstance): boolean;
-  analyze(tree: Node, addon: AddonInstance): Node;
+  analyze(tree: Node, addon: AddonInstance, treeType?: TreeType): Node;
   included(addonInstance: AddonInstance): void;
   updateFastBootManifest(manifest: { vendorFiles: string[] }): void;
 }
@@ -57,12 +58,13 @@ export default class AutoImport implements AutoImportSharedAPI {
     return this.primaryPackage === addon;
   }
 
-  analyze(tree: Node, addon: AddonInstance) {
+  analyze(tree: Node, addon: AddonInstance, treeType?: TreeType) {
     let pack = Package.lookupParentOf(addon);
     this.packages.add(pack);
     let analyzer = new Analyzer(
       debugTree(tree, `preprocessor:input-${this.analyzers.size}`),
-      pack
+      pack,
+      treeType
     );
     this.analyzers.set(analyzer, pack);
     return analyzer;

--- a/packages/ember-auto-import/ts/bundle-config.ts
+++ b/packages/ember-auto-import/ts/bundle-config.ts
@@ -7,6 +7,12 @@ import { dirname } from 'path';
 import { AppInstance } from './ember-cli-models';
 const testsPattern = new RegExp(`^/?[^/]+/(tests|test-support)/`);
 
+import type { TreeType } from './analyzer';
+
+function exhausted(value: never): never {
+  throw new Error(`Unknown tree type specified: ${value}`);
+}
+
 export default class BundleConfig {
   constructor(private emberApp: AppInstance) {}
 
@@ -37,6 +43,21 @@ export default class BundleConfig {
           case 'css':
             return this.emberApp.options.outputPaths.vendor.css.replace(/^\//, '');
         }
+    }
+  }
+
+  bundleForTreeType(treeType: TreeType) {
+    switch (treeType) {
+      case 'app':
+      case 'addon':
+        return 'app';
+
+      case 'addon-test-support':
+      case 'test':
+        return 'test';
+
+      default:
+        exhausted(treeType);
     }
   }
 

--- a/packages/ember-auto-import/ts/index.ts
+++ b/packages/ember-auto-import/ts/index.ts
@@ -23,8 +23,15 @@ module.exports = {
     // it will see all the consumer app or addon's javascript
     registry.add('js', {
       name: 'ember-auto-import-analyzer',
-      toTree: (tree: Node) => {
-        return AutoImport.lookup(this).analyze(tree, this);
+      toTree: (tree: Node, _inputPath: string, _outputPath: string, options: any) => {
+
+        let treeType;
+
+        if (typeof options === 'object' && options !== null && options.treeType) {
+          treeType = options.treeType;
+        }
+
+        return AutoImport.lookup(this).analyze(tree, this, treeType);
       }
     });
   },

--- a/packages/ember-auto-import/ts/splitter.ts
+++ b/packages/ember-auto-import/ts/splitter.ts
@@ -203,13 +203,16 @@ export default class Splitter {
   private chooseBundle(importedBy: Import[]) {
     let usedInBundles = {} as { [bundleName: string]: boolean };
     importedBy.forEach(usage => {
-      usedInBundles[this.bundleForPath(usage)] = true;
+      usedInBundles[this.bundleFor(usage)] = true;
     });
     return this.options.bundles.names.find(bundle => usedInBundles[bundle])!;
   }
 
-  private bundleForPath(usage: Import) {
-    let bundleName = this.options.bundles.bundleForPath(usage.path);
+  private bundleFor(usage: Import) {
+    let bundleName = usage.treeType === undefined || typeof this.options.bundles.bundleForTreeType !== 'function'
+      ? this.options.bundles.bundleForPath(usage.path)
+      : this.options.bundles.bundleForTreeType(usage.treeType);
+
     if (this.options.bundles.names.indexOf(bundleName) === -1) {
       throw new Error(
         `bundleForPath("${

--- a/packages/ember-auto-import/ts/tests/analyzer-test.ts
+++ b/packages/ember-auto-import/ts/tests/analyzer-test.ts
@@ -4,7 +4,7 @@ import { UnwatchedDir } from 'broccoli-source';
 import quickTemp from 'quick-temp';
 import { ensureDirSync, readFileSync, outputFileSync, removeSync, existsSync } from 'fs-extra';
 import { join } from 'path';
-import Package from '../package';
+import type Package from "../package";
 import Analyzer from '../analyzer';
 
 const { module: Qmodule, test } = QUnit;
@@ -14,7 +14,7 @@ Qmodule('analyzer', function(hooks) {
   let builder: Builder;
   let upstream: string;
   let analyzer: Analyzer;
-  let pack: Partial<Package>;
+  let pack: Package;
   let babelOptionsWasAccessed = false;
 
   hooks.beforeEach(function(this: any) {
@@ -26,9 +26,9 @@ Qmodule('analyzer', function(hooks) {
         return {};
       },
       babelMajorVersion: 6,
-      fileExtensions: ['js']
-    };
-    analyzer = new Analyzer(new UnwatchedDir(upstream), pack as Package);
+      fileExtensions: ["js"],
+    } as Package;
+    analyzer = new Analyzer(new UnwatchedDir(upstream), pack);
     builder = new broccoli.Builder(analyzer);
   });
 
@@ -96,7 +96,8 @@ Qmodule('analyzer', function(hooks) {
       isDynamic: false,
       specifier: 'some-package',
       path: 'sample.js',
-      package: pack
+      package: pack,
+      treeType: undefined,
     }]);
   });
 
@@ -113,7 +114,8 @@ Qmodule('analyzer', function(hooks) {
       isDynamic: false,
       specifier: 'some-package',
       path: 'sample.js',
-      package: pack
+      package: pack,
+      treeType: undefined,
     }]);
   });
 
@@ -130,12 +132,14 @@ Qmodule('analyzer', function(hooks) {
       isDynamic: false,
       specifier: 'some-package',
       path: 'sample.js',
-      package: pack
+      package: pack,
+      treeType: undefined,
     },{
       isDynamic: false,
       specifier: 'other-package',
       path: 'sample.js',
-      package: pack
+      package: pack,
+      treeType: undefined,
     }]);
   });
 


### PR DESCRIPTION
Prior to these changes, we would decide what bundle a given file should end up in based on the modules relativePath that imported it. This worked generally for application level tests that import external packages, as well as for many addon-test-support imports.

Unfortunately, this relative path analysis falls down in addons that intentionally customize their `treeForAddonTestSupport` so that the `addon-test-support/` folder contents are available **without** the `addon-name/test-support` suffix. This is done by a number of testing only addons, but the largest offenders are `ember-qunit` and `@ember/test-helpers`.

This introduces a new (possibly undefined) value that can be passed into `preprocessJs` to specify the `treeType` being transpiled. ember-cli will update to pass this value by default, but any addons doing the sort of overrides mentioned above are _likely_ already doing a manual override and can easily pass in the treeType in their overrides.

Fixes https://github.com/ef4/ember-auto-import/issues/284
