### PR TITLE
Ensure `bundleForTreeType` returns the proper values.

### DIFF
--- a/packages/ember-auto-import/ts/analyzer.ts
+++ b/packages/ember-auto-import/ts/analyzer.ts
@@ -28,7 +28,7 @@ makeDebug.formatters.m = (modules: Import[]) => {
 
 const debug = makeDebug('ember-auto-import:analyzer');
 
-export type TreeType = 'app' | 'addon' | 'addon-test-support' | 'test';
+export type TreeType = 'app' | 'addon' | 'addon-templates' | 'addon-test-support' | 'styles' | 'templates' | 'test';
 
 export interface Import {
   path: string;

--- a/packages/ember-auto-import/ts/bundle-config.ts
+++ b/packages/ember-auto-import/ts/bundle-config.ts
@@ -59,6 +59,9 @@ export default class BundleConfig {
     switch (treeType) {
       case 'app':
       case 'addon':
+      case 'addon-templates':
+      case 'styles':
+      case 'templates':
         return 'app';
 
       case 'addon-test-support':

--- a/packages/ember-auto-import/ts/bundle-config.ts
+++ b/packages/ember-auto-import/ts/bundle-config.ts
@@ -9,25 +9,28 @@ const testsPattern = new RegExp(`^/?[^/]+/(tests|test-support)/`);
 
 import type { TreeType } from './analyzer';
 
-function exhausted(value: never): never {
-  throw new Error(`Unknown tree type specified: ${value}`);
+function exhausted(label: string, value: never): never {
+  throw new Error(`Unknown ${label} specified: ${value}`);
 }
+
+export type BundleName = 'app' | 'tests';
+export type BundleType = 'js' | 'css';
 
 export default class BundleConfig {
   constructor(private emberApp: AppInstance) {}
 
   // This list of valid bundles, in priority order. The first one in the list that
   // needs a given import will end up with that import.
-  get names() : ReadonlyArray<string> {
+  get names() : ReadonlyArray<BundleName> {
     return Object.freeze(['app', 'tests']);
   }
 
-  get types(): ReadonlyArray<string> {
+  get types(): ReadonlyArray<BundleType> {
     return Object.freeze(['js', 'css']);
   }
 
   // Which final JS file the given bundle's dependencies should go into.
-  bundleEntrypoint(name: string, type: string): string | undefined {
+  bundleEntrypoint(name: BundleName, type: BundleType): string | undefined {
     switch (name) {
       case 'tests':
         switch (type) {
@@ -35,6 +38,8 @@ export default class BundleConfig {
             return 'assets/test-support.js';
           case 'css':
             return 'assets/test-support.css';
+          default:
+            exhausted('test bundle type', type);
         }
       case 'app':
         switch (type) {
@@ -42,11 +47,15 @@ export default class BundleConfig {
             return this.emberApp.options.outputPaths.vendor.js.replace(/^\//, '');
           case 'css':
             return this.emberApp.options.outputPaths.vendor.css.replace(/^\//, '');
+          default:
+            exhausted('app bundle type', type);
         }
+      default:
+        exhausted('bundle name', name);
     }
   }
 
-  bundleForTreeType(treeType: TreeType) {
+  bundleForTreeType(treeType: TreeType): BundleName {
     switch (treeType) {
       case 'app':
       case 'addon':
@@ -54,16 +63,16 @@ export default class BundleConfig {
 
       case 'addon-test-support':
       case 'test':
-        return 'test';
+        return 'tests';
 
       default:
-        exhausted(treeType);
+        exhausted('bundle name', treeType);
     }
   }
 
   // For any relative path to a module in our application, return which bundle its
   // imports go into.
-  bundleForPath(path: string): string {
+  bundleForPath(path: string): BundleName {
     if (testsPattern.test(path)) {
       return 'tests';
     } else {


### PR DESCRIPTION
When introducing `bundleForTreeType` (in #329) I accidentally emitted an invalid bundle type (`test` vs the correct `tests`). This updates to the correct value, extracts a shared type (to confirm things stay in sync), and adds type assertions to ensure that all cases are handled in both `bundleEntrybundleEntrypoint` and `bundleForPath`.
