### PR TITLE
feat: resolve alias as prefix

### DIFF
--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -273,7 +273,14 @@ export default class Package {
   }
 
   private aliasFor(name: string): string {
-    return (this.autoImportOptions && this.autoImportOptions.alias && this.autoImportOptions.alias[name]) || name;
+    let alias = this.autoImportOptions?.alias;
+    if (!alias) return name;
+    if (alias[name]) return alias[name];
+
+    let prefix = Object.keys(alias).find(p => name.startsWith(`${p}/`));
+    if (prefix) return alias[prefix] + name.slice(prefix.length);
+
+    return name;
   }
 
   get fileExtensions(): string[] {

--- a/packages/sample-direct/app/components/hello-world.js
+++ b/packages/sample-direct/app/components/hello-world.js
@@ -3,6 +3,7 @@ import layout from '../templates/components/hello-world';
 import moment from 'moment';
 import { computed } from '@ember/object';
 import innerLib2 from 'my-aliased-module';
+import aliasedDeeperNamed from 'my-aliased-module/deeper/named';
 import fromScoped from '@ef4/scoped-lib';
 import aModuleDependency from 'a-module-dependency';
 
@@ -15,6 +16,10 @@ export default Component.extend({
 
   aliasedResult: computed(function () {
     return innerLib2();
+  }),
+
+  prefixAliasedResult: computed(function () {
+    return aliasedDeeperNamed();
   }),
 
   fromScoped: computed(function () {

--- a/packages/sample-direct/app/templates/components/hello-world.hbs
+++ b/packages/sample-direct/app/templates/components/hello-world.hbs
@@ -1,5 +1,6 @@
 <div class="hello-world">{{formattedDate}}</div>
 <div class="lodash">{{#if lodashPresent}}yes{{else}}no{{/if}}</div>
 <div class="aliased">{{aliasedResult}}</div>
+<div class="prefix-aliased">{{prefixAliasedResult}}</div>
 <div class="scoped">{{fromScoped}}</div>
 <div class="module-dependency">{{moduleDependency}}</div>

--- a/packages/sample-direct/tests/integration/components/hello-world-test.js
+++ b/packages/sample-direct/tests/integration/components/hello-world-test.js
@@ -16,6 +16,11 @@ module('Integration | Component | hello-world', function (hooks) {
     assert.equal(document.querySelector('.aliased').textContent.trim(), 'innerlib2 loaded');
   });
 
+  test('using a prefix match aliased module', async function (assert) {
+    await render(hbs`{{hello-world}}`);
+    assert.equal(document.querySelector('.prefix-aliased').textContent.trim(), 'deeper named');
+  });
+
   test('using a scoped module', async function (assert) {
     await render(hbs`{{hello-world}}`);
     assert.equal(document.querySelector('.scoped').textContent.trim(), 'this-is-from-ef4-scoped');


### PR DESCRIPTION
Webpack's [`resolve.alias`](https://webpack.js.org/configuration/resolve/#resolvealias) supports resolving prefix aliases.

```js
{
  resolve: {
    alias: {
      'react-query': 'react-query/es'
    }
  }
}
```

For instance the above config translates all paths starting with `react-query`:

- `react-query` ➡️ `react-query/es` (exact match)
- `react-query/foo` ➡️ `react-query/es/foo` (prefix match)
- `react-query-devtools` ➡️ `react-query-devtools` (no match, unchanged)

`ember-auto-import`'s `alias` option only supports exact matches so far.

This PR tweaks the `aliasFor(name)` method to also perform prefix matches in addition to exact matches.