### PR TITLE
Ensure babel compilation ignores a `babel.config.js`

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -163,6 +163,10 @@ export default class WebpackBundler implements BundlerHook {
       use: {
         loader: 'babel-loader-8',
         options: {
+          // do not use the host project's own `babel.config.js` file
+          configFile: false,
+          babelrc: false,
+
           presets: [
             [
               require.resolve('@babel/preset-env'),


### PR DESCRIPTION
Newer versions of ember-cli-babel (>= 7.24.0) will allow folks to move to using the more standard `babel.config.js` (instead of the "magical" configuration that `ember-cli-babel` has done historically).

For example, as of `ember-cli-babel@7.24.0-beta.2` you can add the following:

```js
// babel.config.js
const { buildEmberPlugins } = require('ember-cli-babel');

module.exports = function (api) {
  api.cache(true);

  return {
    presets: [
      [
        '@babel/preset-env',
        {
          targets: require('./config/targets'),
        },
      ],
    ],
    plugins: [...buildEmberPlugins(__dirname)],
  };
};
```

Without the changes here, `babel-loader` runs `@babel/preset-env` twice (once with the config specified by ember-auto-import and once from the configuration in the `babel.config.js`), the `@babel/preset-env` that is configured by the host project however **is** transpiling modules not just syntax which leads to a number of errors in the double transpiled packages.

This can be mitigated by setting up `skipBabel` (as a work around), but changing our internal `babel-loader` to avoid config file loading will ensure that our general ember-auto-import semantics are preserved (e.g.  "we will transpile latest ES syntax for you down to your targets, but nothing more").
