### PR TITLE
ease usage with ember-cli-content-security-policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Supported Options
 
  - `alias`: _object_, Map from package names to substitute packages that will be used instead.
  - `exclude`: _list of strings, defaults to []_. Packages in this list will be ignored by ember-auto-import. Can be helpful if the package is already included another way (like a shim from some other Ember addon).
- - `forbidEval`: _boolean_, defaults to false. We use `eval` in development by default (because that is the fastest way to provide sourcemaps). If you need to comply with a strict Content Security Policy (CSP), you can set `forbidEval: true`. You will still get sourcemaps, they will just use a slower implementation.
+ - `forbidEval`: _boolean_, controls if `eval` is used in development. It is used because that is the fastest way to provide sourcemaps. Defaults to `false` unless [ember-cli-content-security-policy](https://github.com/rwjblue/ember-cli-content-security-policy) is used.
  - `publicAssetURL`: where to load additional dynamic javascript files from. You usually don't need to set this -- the default works for most apps. However, if you're using `<script defer>` or another method of asynchronously loading your vendor.js script you will need to set this to the URL where your asset directory is served (typically `/assets`).
  - `skipBabel`: _list of objects, defaults to []_. The specified packages will be skipped from babel transpilation.
  - `webpack`: _object_, An object that will get merged into the configuration we pass to webpack. This lets you work around quirks in underlying libraries and otherwise customize the way Webpack will assemble your dependencies.
@@ -189,7 +189,9 @@ See [webpack's docs on Node polyfills](https://v4.webpack.js.org/configuration/n
 
 ###  I use Content Security Policy (CSP) and it breaks ember-auto-import.
 
-See `forbidEval` above.
+Ember Auto Import uses `eval` in development if `forbidEval` is `false`. Recent versions detect if [ember-cli-content-security-policy](https://github.com/rwjblue/ember-cli-content-security-policy) is used. `forbidEval` default to `true` in that cases.
+
+If you use an older version or use Content Security Policy without that addon, you should set `forbidEval` option to `true` explicitly.
 
 ### I'm trying to load a jQuery plugin, but it doesn't attach itself to the copy of jQuery that's already in my Ember app.
 

--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -32,6 +32,7 @@
     "@babel/traverse": "^7.1.6",
     "@babel/types": "^7.1.6",
     "@embroider/core": "^0.33.0",
+    "@embroider/macros": "^0.36.0",
     "babel-core": "^6.26.3",
     "babel-loader": "^8.0.6",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1787,6 +1787,45 @@
     walk-sync "^1.1.3"
     wrap-legacy-hbs-plugin-if-needed "^1.0.1"
 
+"@embroider/core@0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@embroider/core/-/core-0.36.0.tgz#fbbd60d29c3fcbe02b4e3e63e6043a43de2b9ce3"
+  integrity sha512-J6esENP+aNt+/r070cF1RCJyCi/Rn1I6uFp37vxyLWwvGDuT0E7wGcaPU29VBkBFqxi4Z1n4F796BaGHv+kX6w==
+  dependencies:
+    "@babel/core" "^7.12.3"
+    "@babel/parser" "^7.12.3"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@babel/plugin-transform-runtime" "^7.12.1"
+    "@babel/runtime" "^7.12.5"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    "@embroider/macros" "0.36.0"
+    assert-never "^1.1.0"
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    broccoli-node-api "^1.7.0"
+    broccoli-persistent-filter "^3.1.2"
+    broccoli-plugin "^4.0.1"
+    broccoli-source "^3.0.0"
+    debug "^3.1.0"
+    escape-string-regexp "^4.0.0"
+    fast-sourcemap-concat "^1.4.0"
+    filesize "^4.1.2"
+    fs-extra "^7.0.1"
+    fs-tree-diff "^2.0.0"
+    handlebars "^4.4.2"
+    js-string-escape "^1.0.1"
+    jsdom "^16.4.0"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.10"
+    pkg-up "^3.1.0"
+    resolve "^1.8.1"
+    resolve-package-path "^1.2.2"
+    semver "^7.3.2"
+    strip-bom "^3.0.0"
+    typescript-memoize "^1.0.0-alpha.3"
+    walk-sync "^1.1.3"
+    wrap-legacy-hbs-plugin-if-needed "^1.0.1"
+
 "@embroider/macros@0.33.0":
   version "0.33.0"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.33.0.tgz#d5826ea7565bb69b57ba81ed528315fe77acbf9d"
@@ -1796,6 +1835,21 @@
     "@babel/traverse" "^7.12.1"
     "@babel/types" "^7.12.1"
     "@embroider/core" "0.33.0"
+    assert-never "^1.1.0"
+    ember-cli-babel "^7.23.0"
+    lodash "^4.17.10"
+    resolve "^1.8.1"
+    semver "^7.3.2"
+
+"@embroider/macros@0.36.0", "@embroider/macros@^0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-0.36.0.tgz#5330f1e6f12112f0f68e34b3e4855dc7dd3c69a5"
+  integrity sha512-w37G4uXG+Wi3K3EHSFBSr/n6kGFXYG8nzZ9ptzDOC7LP3Oh5/MskBnVZW3+JkHXUPEqKsDGlxPxCVpPl1kQyjQ==
+  dependencies:
+    "@babel/core" "^7.12.3"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
+    "@embroider/core" "0.36.0"
     assert-never "^1.1.0"
     ember-cli-babel "^7.23.0"
     lodash "^4.17.10"
@@ -6220,13 +6274,6 @@ ember-cli-version-checker@^4.1.0:
     semver "^6.3.0"
     silent-error "^1.1.1"
 
-"ember-cli-version-checker@git+https://github.com/ef4/ember-cli-version-checker#0e33cbcd7faf17ec804b0c3fb64147b131a015de":
-  version "2.1.2"
-  resolved "git+https://github.com/ef4/ember-cli-version-checker#0e33cbcd7faf17ec804b0c3fb64147b131a015de"
-  dependencies:
-    resolve "^1.3.3"
-    semver "^5.3.0"
-
 ember-cli@*, ember-cli@^3.6.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.13.1.tgz#8daefb108130740cd79ad7e4e1c9138fb1f7313d"
@@ -10432,6 +10479,13 @@ pkg-up@^2.0.0:
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
   dependencies:
     find-up "^2.1.0"
+
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
 
 pn@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Currently all users of [Ember CLI Content Security Policy](https://github.com/rwjblue/ember-cli-content-security-policy) must explicitly set `forbidEval` to `true` in Ember Auto Import's configuration. Unless the very rare case that they allow `"unsafe-eval"` in `style-src` directive.

This is disruptive for users of both sides. Since Ember CLI blueprints for new application includes Ember Auto Import and many addons depend on it as well nearly all user of Ember CLI Content Security Policy must set that configuration. It does not help with adoption of CSP or testing for CSP compliance in Ember ecosystem.

This pull request propose to change the default value to depend on the presence of ember-cli-content-security-policy depenendency. If the application depends on ember-cli-content-security-policy `forbidEval` defaults to `true`. Otherwise it is `false`.

I would not consider this as a breaking change. At least I'm not aware of a meaningful use case to not having `forbidEval` set to `true` if CSP is used.