### PR TITLE
introduce watchDependencies option

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ let app = new EmberApp(defaults, {
         // list can continue
       },
     ],
+    watchDependencies: [
+      // trigger rebuilds if "some-lib" changes during development
+      'some-lib',
+      // trigger rebuilds if "some-lib"'s inner dependency "other-lib" changes
+      ['some-lib', 'other-lib'],
+    ],
     webpack: {
       // extra webpack configuration goes here
     },
@@ -118,6 +124,7 @@ Supported Options
 - `forbidEval`: _boolean_, defaults to false. We use `eval` in development by default (because that is the fastest way to provide sourcemaps). If you need to comply with a strict Content Security Policy (CSP), you can set `forbidEval: true`. You will still get sourcemaps, they will just use a slower implementation.
 - `publicAssetURL`: where to load additional dynamic javascript files from. You usually don't need to set this -- the default works for most apps. However, if you're using `<script defer>` or another method of asynchronously loading your vendor.js script you will need to set this to the URL where your asset directory is served (typically `/assets`).
 - `skipBabel`: _list of objects, defaults to []_. The specified packages will be skipped from babel transpilation.
+- `watchDependencies`: _list of strings or string arrays, defaults to []_. Tells ember-auto-import that you'd like to trigger a rebuild if one of these auto-imported dependencies changes. Pass a package name that refers to one of your own dependencies, or pass an array of package names to address a deeper dependency.
 - `webpack`: _object_, An object that will get merged into the configuration we pass to webpack. This lets you work around quirks in underlying libraries and otherwise customize the way Webpack will assemble your dependencies.
 
 ## Usage from Addons

--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -39,6 +39,7 @@
     "broccoli-debug": "^0.6.4",
     "broccoli-node-api": "^1.7.0",
     "broccoli-plugin": "^4.0.0",
+    "broccoli-source": "^3.0.0",
     "debug": "^3.1.0",
     "ember-cli-babel": "^7.0.0",
     "enhanced-resolve": "^4.0.0",

--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -1,5 +1,5 @@
 import resolvePackagePath from 'resolve-package-path';
-import { join } from 'path';
+import { join, dirname } from 'path';
 import { readFileSync } from 'fs';
 import { Memoize } from 'typescript-memoize';
 import { Configuration } from 'webpack';
@@ -19,6 +19,7 @@ export interface Options {
   publicAssetURL?: string;
   forbidEval?: boolean;
   skipBabel?: { package: string; semverRange?: string }[];
+  watchDependencies?: (string | string[])[];
 }
 
 interface DepResolution {
@@ -304,6 +305,31 @@ export default class Package {
     // only apps (not addons) are allowed to set this, because it's motivated by
     // the apps own Content Security Policy.
     return Boolean(!this.isAddon && this.autoImportOptions && this.autoImportOptions.forbidEval);
+  }
+
+  get watchedDirectories(): string[] | undefined {
+    // only apps (not addons) are allowed to set this
+    if (!this.isAddon && this.autoImportOptions?.watchDependencies) {
+      return this.autoImportOptions.watchDependencies
+        .map(nameOrNames => {
+          let names: string[];
+          if (typeof nameOrNames === 'string') {
+            names = [nameOrNames];
+          } else {
+            names = nameOrNames;
+          }
+          let cursor = this.root;
+          for (let name of names) {
+            let path = resolvePackagePath(name, cursor);
+            if (!path) {
+              return undefined;
+            }
+            cursor = dirname(path);
+          }
+          return cursor;
+        })
+        .filter(Boolean) as string[];
+    }
   }
 }
 

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -114,7 +114,9 @@ export default class WebpackBundler implements BundlerHook {
       },
       output: {
         path: this.outputDir,
-        filename: `chunk.[id].[chunkhash].js`,
+        // entry chunks need to have stable names, so we can more easily gather
+        // them all up to append to Ember's vendor.js
+        filename: `chunk.[id].js`,
         chunkFilename: `chunk.[id].[chunkhash].js`,
         libraryTarget: 'var',
         library: '__ember_auto_import__',
@@ -122,6 +124,12 @@ export default class WebpackBundler implements BundlerHook {
       optimization: {
         splitChunks: {
           chunks: 'all',
+          cacheGroups: {
+            // similar to above, entry vendor chunks need to have stable names
+            vendors: {
+              filename: 'chunk.[name].js',
+            } as any, // typings are missing a valid documented option
+          },
         },
       },
       resolveLoader: {
@@ -163,10 +171,6 @@ export default class WebpackBundler implements BundlerHook {
       use: {
         loader: 'babel-loader-8',
         options: {
-          // do not use the host project's own `babel.config.js` file
-          configFile: false,
-          babelrc: false,
-
           presets: [
             [
               require.resolve('@babel/preset-env'),


### PR DESCRIPTION
This lets you rebuild in development when editing an auto-imported package.