### PR TITLE
Revert "feat: resolve alias as prefix"

### DIFF
--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -271,14 +271,7 @@ export default class Package {
   }
 
   private aliasFor(name: string): string {
-    let alias = this.autoImportOptions?.alias;
-    if (!alias) return name;
-    if (alias[name]) return alias[name];
-
-    let prefix = Object.keys(alias).find(p => name.startsWith(`${p}/`));
-    if (prefix) return alias[prefix] + name.slice(prefix.length);
-
-    return name;
+    return (this.autoImportOptions && this.autoImportOptions.alias && this.autoImportOptions.alias[name]) || name;
   }
 
   get fileExtensions(): string[] {

--- a/test-scenarios/static-import-test.ts
+++ b/test-scenarios/static-import-test.ts
@@ -35,7 +35,6 @@ function staticImportTest(project: Project) {
             import moment from 'moment';
             import { computed } from '@ember/object';
             import myAliased from 'my-aliased-package';
-            import aliasedDeeperNamed from 'my-aliased-package/deeper/named';
             import fromScoped from '@ef4/scoped-lib';
 
             export default Component.extend({
@@ -45,10 +44,6 @@ function staticImportTest(project: Project) {
 
               aliasedResult: computed(function () {
                 return myAliased();
-              }),
-
-              prefixAliasedResult: computed(function () {
-                return aliasedDeeperNamed();
               }),
 
               fromScoped: computed(function () {
@@ -76,7 +71,6 @@ function staticImportTest(project: Project) {
               <div class="hello-world">{{formattedDate}}</div>
               <div class="lodash">{{#if lodashPresent}}yes{{else}}no{{/if}}</div>
               <div class="aliased">{{aliasedResult}}</div>
-              <div class="prefix-aliased">{{prefixAliasedResult}}</div>
               <div class="scoped">{{fromScoped}}</div>
             `,
         },
@@ -102,11 +96,6 @@ function staticImportTest(project: Project) {
                 test('using an aliased module', async function (assert) {
                   await render(hbs('{{hello-world}}'));
                   assert.equal(document.querySelector('.aliased').textContent.trim(), 'original-package');
-                });
-
-                test('using a prefix match aliased module', async function (assert) {
-                  await render(hbs('{{hello-world}}'));
-                  assert.equal(document.querySelector('.prefix-aliased').textContent.trim(), 'deeper/named');
                 });
 
                 test('using a scoped module', async function (assert) {
@@ -148,9 +137,6 @@ function staticImportTest(project: Project) {
           module.exports = function() {
             return 'original-package';
           }`,
-      deeper: {
-        'named.js': `module.exports = function() { return "deeper/named" };`,
-      },
     },
   });
 


### PR DESCRIPTION
This reverts commit 90d1680324c9423d463de1de82e9e94688b57130.

We will still want to roll this feature out, but
 - we can't do it in a minor release
 - if we're going to make this change to follow webpack's `resolve.alias`, we should really implement all of `resolve.alias`, including the trailing `$` for exact matches.