### PR TITLE
Fix config duplication

### DIFF
--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -5,7 +5,12 @@ import { Memoize } from 'typescript-memoize';
 import { Configuration } from 'webpack';
 import { AddonInstance, isDeepAddonInstance, Project } from './ember-cli-models';
 
-const cache: WeakMap<AddonInstance, Package> = new WeakMap();
+// from child addon instance to their parent package
+const parentCache: WeakMap<AddonInstance, Package> = new WeakMap();
+
+// from an addon instance or project to its package
+const packageCache: WeakMap<AddonInstance | Project, Package> = new WeakMap();
+
 let pkgGeneration = 0;
 
 export function reloadDevPackages() {
@@ -62,10 +67,15 @@ export default class Package {
   private pkgCache: any;
 
   static lookupParentOf(child: AddonInstance): Package {
-    if (!cache.has(child)) {
-      cache.set(child, new this(child));
+    if (!parentCache.has(child)) {
+      let pkg = packageCache.get(child.parent);
+      if (!pkg) {
+        pkg = new this(child);
+        packageCache.set(child.parent, pkg);
+      }
+      parentCache.set(child, pkg);
     }
-    return cache.get(child)!;
+    return parentCache.get(child)!;
   }
 
   constructor(child: AddonInstance) {

--- a/test-scenarios/package.json
+++ b/test-scenarios/package.json
@@ -28,6 +28,7 @@
     "ember-cli-typescript-2": "npm:ember-cli-typescript@^2.0.0-beta.3",
     "ember-cli-typescript-3": "npm:ember-cli-typescript@^3.0.0",
     "ember-cli-typescript-4": "npm:ember-cli-typescript@^4.0.0-alpha.1",
+    "js-string-escape": "^1.0.1",
     "lodash": "^4.17.20",
     "lodash-es": "^4.17.10",
     "moment": "^2.22.1",


### PR DESCRIPTION
This fixes https://github.com/ef4/ember-auto-import/issues/349 by caching on the parent addon or app's own identity, as well as caching from the child.