### PR TITLE
fix(analyzer): ignore type-only imports & exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -828,10 +828,12 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==",
-      "license": "MIT"
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
       "version": "7.13.0",
@@ -1696,12 +1698,14 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz",
-      "integrity": "sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==",
-      "license": "MIT",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+      "integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -14933,17 +14937,18 @@
     },
     "node_modules/ember-cli-latest": {
       "name": "ember-cli",
-      "version": "3.26.1",
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.27.0.tgz",
+      "integrity": "sha512-vFLPFkplXn5v005fattHdOcs5AbSp7RG4w1wpHDWHzOSYpl2Dr+5zzZtqLS7V5IVaLf3XK4l24XwhSW9HpMfsQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.12.10",
+        "@babel/core": "^7.13.8",
         "@babel/plugin-transform-modules-amd": "^7.12.1",
         "amd-name-resolver": "^1.3.1",
-        "babel-plugin-module-resolver": "^4.0.0",
+        "babel-plugin-module-resolver": "^4.1.0",
         "bower-config": "^1.4.3",
         "bower-endpoint-parser": "0.2.2",
-        "broccoli": "^3.5.0",
+        "broccoli": "^3.5.1",
         "broccoli-amd-funnel": "^2.0.1",
         "broccoli-babel-transpiler": "^7.8.0",
         "broccoli-builder": "^0.18.14",
@@ -14982,7 +14987,7 @@
         "filesize": "^6.1.0",
         "find-up": "^5.0.0",
         "find-yarn-workspace-root": "^2.0.0",
-        "fixturify-project": "^2.1.0",
+        "fixturify-project": "^2.1.1",
         "fs-extra": "^9.1.0",
         "fs-tree-diff": "^2.0.1",
         "get-caller-file": "^2.0.5",
@@ -15006,13 +15011,13 @@
         "minimatch": "^3.0.4",
         "morgan": "^1.10.0",
         "nopt": "^3.0.6",
-        "npm-package-arg": "^8.1.0",
+        "npm-package-arg": "^8.1.1",
         "p-defer": "^3.0.0",
         "portfinder": "^1.0.28",
         "promise-map-series": "^0.3.0",
         "promise.hash.helper": "^1.0.7",
         "quick-temp": "^0.1.8",
-        "resolve": "^1.19.0",
+        "resolve": "^1.20.0",
         "resolve-package-path": "^3.1.0",
         "sane": "^4.1.0",
         "semver": "^7.3.4",
@@ -42663,6 +42668,7 @@
         "walk-sync": "^0.3.3"
       },
       "devDependencies": {
+        "@babel/plugin-syntax-typescript": "^7.14.5",
         "@types/babel__core": "^7.0.4",
         "@types/babel__generator": "^7.0.1",
         "@types/babel__template": "^7.0.1",
@@ -44939,9 +44945,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
-      "integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.13.0",
@@ -45637,11 +45643,11 @@
       }
     },
     "@babel/plugin-syntax-typescript": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.12.13.tgz",
-      "integrity": "sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+      "integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13"
+        "@babel/helper-plugin-utils": "^7.14.5"
       }
     },
     "@babel/plugin-transform-arrow-functions": {
@@ -57085,6 +57091,7 @@
         "@babel/core": "^7.1.6",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5",
         "@babel/preset-env": "^7.10.2",
         "@babel/traverse": "^7.1.6",
         "@babel/types": "^7.1.6",
@@ -60504,16 +60511,18 @@
       "dev": true
     },
     "ember-cli-latest": {
-      "version": "npm:ember-cli@3.26.1",
+      "version": "npm:ember-cli@3.27.0",
+      "resolved": "https://registry.npmjs.org/ember-cli/-/ember-cli-3.27.0.tgz",
+      "integrity": "sha512-vFLPFkplXn5v005fattHdOcs5AbSp7RG4w1wpHDWHzOSYpl2Dr+5zzZtqLS7V5IVaLf3XK4l24XwhSW9HpMfsQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.12.10",
+        "@babel/core": "^7.13.8",
         "@babel/plugin-transform-modules-amd": "^7.12.1",
         "amd-name-resolver": "^1.3.1",
-        "babel-plugin-module-resolver": "^4.0.0",
+        "babel-plugin-module-resolver": "^4.1.0",
         "bower-config": "^1.4.3",
         "bower-endpoint-parser": "0.2.2",
-        "broccoli": "^3.5.0",
+        "broccoli": "^3.5.1",
         "broccoli-amd-funnel": "^2.0.1",
         "broccoli-babel-transpiler": "^7.8.0",
         "broccoli-builder": "^0.18.14",
@@ -60552,7 +60561,7 @@
         "filesize": "^6.1.0",
         "find-up": "^5.0.0",
         "find-yarn-workspace-root": "^2.0.0",
-        "fixturify-project": "^2.1.0",
+        "fixturify-project": "^2.1.1",
         "fs-extra": "^9.1.0",
         "fs-tree-diff": "^2.0.1",
         "get-caller-file": "^2.0.5",
@@ -60576,13 +60585,13 @@
         "minimatch": "^3.0.4",
         "morgan": "^1.10.0",
         "nopt": "^3.0.6",
-        "npm-package-arg": "^8.1.0",
+        "npm-package-arg": "^8.1.1",
         "p-defer": "^3.0.0",
         "portfinder": "^1.0.28",
         "promise-map-series": "^0.3.0",
         "promise.hash.helper": "^1.0.7",
         "quick-temp": "^0.1.8",
-        "resolve": "^1.19.0",
+        "resolve": "^1.20.0",
         "resolve-package-path": "^3.1.0",
         "sane": "^4.1.0",
         "semver": "^7.3.4",

--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -63,6 +63,7 @@
     "walk-sync": "^0.3.3"
   },
   "devDependencies": {
+    "@babel/plugin-syntax-typescript": "^7.14.5",
     "@types/babel__core": "^7.0.4",
     "@types/babel__generator": "^7.0.1",
     "@types/babel__template": "^7.0.1",

--- a/packages/ember-auto-import/ts/tests/analyzer-test.ts
+++ b/packages/ember-auto-import/ts/tests/analyzer-test.ts
@@ -175,6 +175,35 @@ Qmodule('analyzer', function (hooks) {
     assert.deepEqual(analyzer.imports, []);
   });
 
+  test('type-only imports ignored in created file', async function (assert) {
+    await builder.build();
+    let original = `
+      import type Foo from 'type-import';
+      import Bar from 'value-import';
+
+      export type { Qux } from 'type-re-export';
+      export { Baz } from 'value-re-export';
+    `;
+    outputFileSync(join(upstream, 'sample.js'), original);
+    await builder.build();
+    assert.deepEqual(analyzer.imports, [
+      {
+        isDynamic: false,
+        specifier: 'value-import',
+        path: 'sample.js',
+        package: pack,
+        treeType: undefined,
+      },
+      {
+        isDynamic: false,
+        specifier: 'value-re-export',
+        path: 'sample.js',
+        package: pack,
+        treeType: undefined,
+      },
+    ]);
+  });
+
   type LiteralExample = [string, string];
   type TemplateExample = [string, string[], string[]];
   function isLiteralExample(exp: LiteralExample | TemplateExample): exp is LiteralExample {

--- a/packages/ember-auto-import/ts/tests/analyzer-test.ts
+++ b/packages/ember-auto-import/ts/tests/analyzer-test.ts
@@ -24,7 +24,7 @@ Qmodule('analyzer', function (hooks) {
       get babelOptions() {
         babelOptionsWasAccessed = true;
         return {
-          plugins: [require.resolve('../../babel-plugin')],
+          plugins: [require.resolve('@babel/plugin-syntax-typescript'), require.resolve('../../babel-plugin')],
         };
       },
       babelMajorVersion: 7,


### PR DESCRIPTION
Prevents [type-only imports / exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) from ending up in the final bundle.

```ts
import type { compute } from 'heavy-library';

export async function performHeavyComputation(
  ...args: Parameters<typeof compute>
): Promise<ReturnType<typeof compute>> {
  const { compute } = await import('heavy-library');
  return compute(...args);
}
```