### PR TITLE
silence babel's unhelpful warning

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -168,6 +168,13 @@ export default class WebpackBundler implements BundlerHook {
           configFile: false,
           babelrc: false,
 
+          // leaving this unset can generate an unhelpful warning from babel on
+          // large files like 'Note: The code generator has deoptimised the
+          // styling of... as it exceeds the max of 500KB."
+          generatorOpts: {
+            compact: true,
+          },
+
           presets: [
             [
               require.resolve('@babel/preset-env'),


### PR DESCRIPTION
I don't think anyone has ever found this message helpful:

> The code generator has deoptimised the styling of ... as it exceeds the max of 500KB.

As long as we provide a setting (as opposed to leaving it in auto), babel won't emit the warning.