### PR TITLE
reactivate test under canary

### DIFF
--- a/test-scenarios/import-sync-test.ts
+++ b/test-scenarios/import-sync-test.ts
@@ -6,12 +6,6 @@ import { setupFastboot } from './fastboot-helper';
 const { module: Qmodule, test } = QUnit;
 
 appScenarios
-  // temporarily skipping canary because it has a breaking change that breaks
-  // @embroider/macros, and in here we are testing our interaction with
-  // @embroider/macros
-  //
-  // https://github.com/ember-cli/ember-cli/issues/9522
-  .skip('canary')
   .map('import-sync', project => {
     project.linkDependency('ember-auto-import', { baseDir: __dirname });
     project.linkDependency('webpack', { baseDir: __dirname });


### PR DESCRIPTION
https://github.com/ember-cli/ember-cli/pull/9523 is fixed upstream so this test is expected to pass now.