### PR TITLE
docs(CHANGELOG): fix link to guide upgrade to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.0.0
 
-- BREAKING: see [./docs/upgrade-guide-2.0.md] for the complete list of breaking changes in 2.0 with explanations and instructions.
+- BREAKING: see the [upgrade guide to v2](./docs/upgrade-guide-2.0.md) for the complete list of breaking changes in 2.0 with explanations and instructions.
 - BREAKING: webpack 5 upgrade by @gabrielcsapo and @ef4
 - BREAKING ENHANCEMENT: support embroider v2-formatted addons
 - BREAKING: drop support for babel 6


### PR DESCRIPTION
Fix link to the guide "upgrade to version 2"