### PR TITLE
fix inconsistent "loose" babel warning

### DIFF
--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -401,7 +401,7 @@ export default class Package {
 
     let plugins = [
       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],
-      [require.resolve('@babel/plugin-proposal-class-properties'), { loose: true }],
+      [require.resolve('@babel/plugin-proposal-class-properties'), { loose: false }],
       [
         require.resolve('babel-plugin-htmlbars-inline-precompile'),
         {


### PR DESCRIPTION
Fixes #403.

We originally used loose here because ember-cli-babel did, because it was required when using decorators. But that is no longer true and ember-cli-babel also defaults to strict.