### PR TITLE
Support Customized HTML Insertion and Custom Entrypoints

### DIFF
--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -54,7 +54,7 @@ export default class AutoImport implements AutoImportSharedAPI {
     this.packages.add(Package.lookupParentOf(topmostAddon));
     let host = topmostAddon.app;
     this.env = host.env;
-    this.bundles = new BundleConfig(host);
+    this.bundles = new BundleConfig(host.options.outputPaths);
     if (!this.env) {
       throw new Error('Bug in ember-auto-import: did not discover environment');
     }

--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -122,7 +122,7 @@ export default class AutoImport implements AutoImportSharedAPI {
       bundles: this.bundles,
       babelConfig: this.rootPackage.cleanBabelConfig(),
       browserslist: this.rootPackage.browserslist(),
-      publicAssetURL: this.publicAssetURL,
+      publicAssetURL: this.rootPackage.publicAssetURL(),
       webpack,
     });
   }
@@ -136,15 +136,13 @@ export default class AutoImport implements AutoImportSharedAPI {
     return rootPackage;
   }
 
-  private get publicAssetURL(): string | undefined {
-    // Only the app (not an addon) can customize the public asset URL, because
-    // it's an app concern.
-    return this.rootPackage.publicAssetURL;
-  }
-
   addTo(allAppTree: Node): Node {
     let bundler = debugBundler(this.makeBundler(allAppTree), 'output');
-    let inserter = new Inserter(allAppTree, bundler, this.bundles, this.publicAssetURL);
+    let inserter = new Inserter(allAppTree, bundler, this.bundles, {
+      publicAssetURL: this.rootPackage.publicAssetURL(),
+      insertScriptsAt: this.rootPackage.insertScriptsAt,
+      insertStylesAt: this.rootPackage.insertStylesAt,
+    });
     let trees = [allAppTree, bundler, inserter];
     return mergeTrees(trees, { overwrite: true });
   }

--- a/packages/ember-auto-import/ts/bundle-config.ts
+++ b/packages/ember-auto-import/ts/bundle-config.ts
@@ -4,7 +4,6 @@
 */
 
 import { dirname } from 'path';
-import { AppInstance } from '@embroider/shared-internals';
 const testsPattern = new RegExp(`^(@[^/]+)?/?[^/]+/(tests|test-support)/`);
 
 import type { TreeType } from './analyzer';
@@ -16,8 +15,18 @@ function exhausted(label: string, value: never): never {
 export type BundleName = 'app' | 'tests';
 export type BundleType = 'js' | 'css';
 
+interface OutputPaths {
+  vendor: {
+    js: string;
+    css: string;
+  };
+  app: {
+    html: string;
+  };
+}
+
 export default class BundleConfig {
-  constructor(private emberApp: AppInstance) {}
+  constructor(private outputPaths: OutputPaths) {}
 
   // This list of valid bundles, in priority order. The first one in the list that
   // needs a given import will end up with that import.
@@ -50,9 +59,9 @@ export default class BundleConfig {
       case 'app':
         switch (type) {
           case 'js':
-            return this.emberApp.options.outputPaths.vendor.js.replace(/^\//, '');
+            return this.outputPaths.vendor.js.replace(/^\//, '');
           case 'css':
-            return this.emberApp.options.outputPaths.vendor.css.replace(/^\//, '');
+            return this.outputPaths.vendor.css.replace(/^\//, '');
           default:
             exhausted('app bundle type', type);
         }
@@ -94,6 +103,6 @@ export default class BundleConfig {
   }
 
   htmlEntrypoints() {
-    return [this.emberApp.options.outputPaths.app.html, 'tests/index.html'];
+    return [this.outputPaths.app.html, 'tests/index.html'];
   }
 }

--- a/packages/ember-auto-import/ts/bundle-config.ts
+++ b/packages/ember-auto-import/ts/bundle-config.ts
@@ -34,10 +34,8 @@ export default class BundleConfig {
     return Object.freeze(['app', 'tests']);
   }
 
-  assertValidBundleName(name: string): asserts name is BundleName {
-    if (!this.names.includes(name as BundleName)) {
-      throw new Error(`bug: ${name} is not a known bundle name`);
-    }
+  isBuiltInBundleName(name: string): name is BundleName {
+    return this.names.includes(name as BundleName);
   }
 
   get types(): ReadonlyArray<BundleType> {

--- a/packages/ember-auto-import/ts/bundler.ts
+++ b/packages/ember-auto-import/ts/bundler.ts
@@ -22,7 +22,10 @@ export interface BundlerOptions {
 }
 
 export interface BuildResult {
-  entrypoints: Map<BundleName, string[]>;
+  // the keys here include both our well-known BundleName's (which are defined
+  // automatically by ember-auto-import) as well as arbitrary string bundle
+  // names (because users can also add more entrypoints to the webpack config)
+  entrypoints: Map<BundleName | string, string[]>;
   lazyAssets: string[];
 }
 

--- a/packages/ember-auto-import/ts/inserter.ts
+++ b/packages/ember-auto-import/ts/inserter.ts
@@ -10,12 +10,18 @@ import { BuildResult, Bundler } from './bundler';
 
 const debug = makeDebug('ember-auto-import:inserter');
 
+export interface InserterOptions {
+  publicAssetURL: string | undefined;
+  insertScriptsAt: string | undefined;
+  insertStylesAt: string | undefined;
+}
+
 export class Inserter extends Plugin {
   constructor(
     allApp: InputNode,
     private bundler: Bundler,
     private config: BundleConfig,
-    private publicAssetURL: string | undefined
+    private options: InserterOptions
   ) {
     super([allApp], {
       annotation: 'ember-auto-import-inserter',
@@ -142,8 +148,8 @@ export class Inserter extends Plugin {
   }
 
   private chunkURL(rootURL: string, chunk: string) {
-    if (this.publicAssetURL) {
-      return chunk.replace(/^assets\//, this.publicAssetURL);
+    if (this.options.publicAssetURL) {
+      return chunk.replace(/^assets\//, this.options.publicAssetURL);
     } else {
       return `${rootURL}${chunk}`;
     }

--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -34,6 +34,8 @@ export interface Options {
   forbidEval?: boolean;
   skipBabel?: { package: string; semverRange?: string }[];
   watchDependencies?: (string | string[])[];
+  insertScriptsAt?: string;
+  insertStylesAt?: string;
 }
 
 interface DepResolution {
@@ -346,7 +348,11 @@ export default class Package {
     return this._emberCLIBabelExtensions!;
   }
 
-  get publicAssetURL(): string | undefined {
+  publicAssetURL(): string | undefined {
+    // only apps (not addons) are allowed to set this
+    if (this.isAddon) {
+      return undefined;
+    }
     let url = this.autoImportOptions && this.autoImportOptions.publicAssetURL;
     if (url) {
       if (url[url.length - 1] !== '/') {
@@ -370,6 +376,20 @@ export default class Package {
     // only apps (not addons) are allowed to set this, because it's motivated by
     // the apps own Content Security Policy.
     return Boolean(!this.isAddon && this.autoImportOptions && this.autoImportOptions.forbidEval);
+  }
+
+  get insertScriptsAt(): string | undefined {
+    if (this.isAddon) {
+      throw new Error(`bug: only apps should control insertScriptsAt`);
+    }
+    return this.autoImportOptions?.insertScriptsAt;
+  }
+
+  get insertStylesAt(): string | undefined {
+    if (this.isAddon) {
+      throw new Error(`bug: only apps should control insertStylesAt`);
+    }
+    return this.autoImportOptions?.insertStylesAt;
   }
 
   get watchedDirectories(): string[] | undefined {

--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -348,18 +348,13 @@ export default class Package {
     return this._emberCLIBabelExtensions!;
   }
 
-  publicAssetURL(): string | undefined {
-    // only apps (not addons) are allowed to set this
+  publicAssetURL(): string {
     if (this.isAddon) {
-      return undefined;
+      throw new Error(`bug: only the app should control publicAssetURL`);
     }
-    let url = this.autoImportOptions && this.autoImportOptions.publicAssetURL;
-    if (url) {
-      if (url[url.length - 1] !== '/') {
-        url = url + '/';
-      }
-    }
-    return url;
+    return ensureTrailingSlash(
+      this.autoImportOptions?.publicAssetURL ?? ensureTrailingSlash((this._parent as any).config().rootURL) + 'assets/'
+    );
   }
 
   get styleLoaderOptions(): Record<string, unknown> | undefined {
@@ -523,4 +518,11 @@ function isPrecise(leadingQuasi: string): boolean {
   let slashes = count(leadingQuasi, '/');
   let minSlashes = leadingQuasi.startsWith('@') ? 2 : 1;
   return slashes >= minSlashes;
+}
+
+function ensureTrailingSlash(url: string): string {
+  if (url[url.length - 1] !== '/') {
+    url = url + '/';
+  }
+  return url;
 }

--- a/packages/ember-auto-import/ts/tests/inserter-test.ts
+++ b/packages/ember-auto-import/ts/tests/inserter-test.ts
@@ -153,4 +153,26 @@ Qmodule('inserter', function (hooks) {
       `<link rel="stylesheet" href="https://cdn.com/1234/assets/vendor.css"/>\n<link rel="stylesheet" href="https://cdn.com/1234/assets/chunk.1.css"/>`
     );
   });
+
+  test('uses customized publicAssetURL for JS', async function (assert) {
+    publicAssetURL = 'https://cdn.com/4321/assets/';
+    buildResult.entrypoints.set('app', ['assets/chunk.1.js']);
+    writeIndex(`<script src="/assets/vendor.js"></script>`);
+    await build();
+    assert.equal(
+      readIndex(),
+      `<script src="/assets/vendor.js"></script>\n<script src="https://cdn.com/4321/assets/chunk.1.js"></script>`
+    );
+  });
+
+  test('uses customized publicAssetURL for css', async function (assert) {
+    publicAssetURL = 'https://cdn.com/4321/assets/';
+    buildResult.entrypoints.set('app', ['assets/chunk.1.css']);
+    writeIndex(`<link rel="stylesheet" href="/assets/vendor.css"/>`);
+    await build();
+    assert.equal(
+      readIndex(),
+      `<link rel="stylesheet" href="/assets/vendor.css"/>\n<link rel="stylesheet" href="https://cdn.com/4321/assets/chunk.1.css"/>`
+    );
+  });
 });

--- a/packages/ember-auto-import/ts/tests/inserter-test.ts
+++ b/packages/ember-auto-import/ts/tests/inserter-test.ts
@@ -13,7 +13,7 @@ const { module: Qmodule, test } = QUnit;
 Qmodule('inserter', function (hooks) {
   let builder: Builder;
   let upstream: string;
-  let publicAssetURL: string | undefined;
+  let publicAssetURL: string;
   let bundleConfig: BundleConfig;
   let buildResult: BuildResult;
   let insertScriptsAt: string | undefined;
@@ -50,7 +50,7 @@ Qmodule('inserter', function (hooks) {
       },
       vendor: { css: '/assets/vendor.css', js: '/assets/vendor.js' },
     });
-    publicAssetURL = undefined;
+    publicAssetURL = '/assets/';
   });
 
   hooks.afterEach(function (this: any) {
@@ -131,26 +131,6 @@ Qmodule('inserter', function (hooks) {
     assert.equal(
       readIndex(),
       `<link rel="stylesheet" href="/assets/rodnev.css"/>\n<link rel="stylesheet" href="/assets/chunk.1.css"/>`
-    );
-  });
-
-  test('uses same rootURL as vendor.js', async function (assert) {
-    buildResult.entrypoints.set('app', ['assets/chunk.1.js']);
-    writeIndex(`<script src="https://cdn.com/1234/assets/vendor.js"></script>`);
-    await build();
-    assert.equal(
-      readIndex(),
-      `<script src="https://cdn.com/1234/assets/vendor.js"></script>\n<script src="https://cdn.com/1234/assets/chunk.1.js"></script>`
-    );
-  });
-
-  test('uses same rootURL as vendor.css', async function (assert) {
-    buildResult.entrypoints.set('app', ['assets/chunk.1.css']);
-    writeIndex(`<link rel="stylesheet" href="https://cdn.com/1234/assets/vendor.css"/>`);
-    await build();
-    assert.equal(
-      readIndex(),
-      `<link rel="stylesheet" href="https://cdn.com/1234/assets/vendor.css"/>\n<link rel="stylesheet" href="https://cdn.com/1234/assets/chunk.1.css"/>`
     );
   });
 

--- a/packages/ember-auto-import/ts/tests/inserter-test.ts
+++ b/packages/ember-auto-import/ts/tests/inserter-test.ts
@@ -1,0 +1,150 @@
+import QUnit from 'qunit';
+import 'qunit-assertions-extra';
+import broccoli, { Builder } from 'broccoli';
+import { UnwatchedDir } from 'broccoli-source';
+import quickTemp from 'quick-temp';
+import { ensureDirSync, readFileSync, outputFileSync, removeSync } from 'fs-extra';
+import { join } from 'path';
+import { Inserter } from '../inserter';
+import BundleConfig from '../bundle-config';
+import { BuildResult, Bundler } from '../bundler';
+const { module: Qmodule, test } = QUnit;
+
+Qmodule('inserter', function (hooks) {
+  let builder: Builder;
+  let upstream: string;
+  let publicAssetURL: string | undefined;
+  let bundleConfig: BundleConfig;
+  let buildResult: BuildResult;
+
+  async function build() {
+    let inserter = new Inserter(new UnwatchedDir(upstream), { buildResult } as Bundler, bundleConfig, publicAssetURL);
+    builder = new broccoli.Builder(inserter);
+    await builder.build();
+  }
+
+  function writeIndex(src: string) {
+    outputFileSync(join(upstream, 'index.html'), src);
+  }
+
+  function readIndex(): string {
+    return readFileSync(join(builder.outputPath, 'index.html'), 'utf8');
+  }
+
+  hooks.beforeEach(function (this: any) {
+    quickTemp.makeOrRemake(this, 'workDir', 'auto-import-inserter-tests');
+    ensureDirSync((upstream = join(this.workDir, 'upstream')));
+    buildResult = {
+      entrypoints: new Map(),
+      lazyAssets: [],
+    };
+    bundleConfig = new BundleConfig({
+      app: {
+        html: 'index.html',
+      },
+      vendor: { css: '/assets/vendor.css', js: '/assets/vendor.js' },
+    });
+    publicAssetURL = undefined;
+  });
+
+  hooks.afterEach(function (this: any) {
+    removeSync(this.workDir);
+    if (builder) {
+      return builder.cleanup();
+    }
+  });
+
+  test('does not error when we have nothing to insert', async function (assert) {
+    writeIndex('');
+    await build();
+    assert.expect(0);
+  });
+
+  test('errors when we cannot find a place for app js', async function (assert) {
+    buildResult.entrypoints.set('app', ['assets/chunk.1.js']);
+    writeIndex('');
+    try {
+      await build();
+      throw new Error('should not get here');
+    } catch (err: any) {
+      assert.contains(err.message, 'ember-auto-import could not find a place to insert app scripts in index.html');
+    }
+  });
+
+  test('errors when we cannot find a place for app css', async function (assert) {
+    buildResult.entrypoints.set('app', ['assets/chunk.1.css']);
+    writeIndex('');
+    try {
+      await build();
+      throw new Error('should not get here');
+    } catch (err: any) {
+      assert.contains(err.message, 'ember-auto-import could not find a place to insert app styles in index.html');
+    }
+  });
+
+  test('inserts app scripts after vendor.js', async function (assert) {
+    buildResult.entrypoints.set('app', ['assets/chunk.1.js']);
+    writeIndex(`<script src="/assets/vendor.js"></script>`);
+    await build();
+    assert.equal(readIndex(), `<script src="/assets/vendor.js"></script>\n<script src="/assets/chunk.1.js"></script>`);
+  });
+
+  test('inserts app styles after vendor.css', async function (assert) {
+    buildResult.entrypoints.set('app', ['assets/chunk.1.css']);
+    writeIndex(`<link rel="stylesheet" href="/assets/vendor.css"/>`);
+    await build();
+    assert.equal(
+      readIndex(),
+      `<link rel="stylesheet" href="/assets/vendor.css"/>\n<link rel="stylesheet" href="/assets/chunk.1.css"/>`
+    );
+  });
+
+  test('inserts app scripts after customized vendor.js', async function (assert) {
+    bundleConfig = new BundleConfig({
+      app: {
+        html: 'index.html',
+      },
+      vendor: { css: '/assets/vendor.css', js: '/assets/rodnev.js' },
+    });
+    buildResult.entrypoints.set('app', ['assets/chunk.1.js']);
+    writeIndex(`<script src="/assets/rodnev.js"></script>`);
+    await build();
+    assert.equal(readIndex(), `<script src="/assets/rodnev.js"></script>\n<script src="/assets/chunk.1.js"></script>`);
+  });
+
+  test('inserts app styles after customized vendor.css', async function (assert) {
+    bundleConfig = new BundleConfig({
+      app: {
+        html: 'index.html',
+      },
+      vendor: { css: '/assets/rodnev.css', js: '/assets/rodnev.js' },
+    });
+    buildResult.entrypoints.set('app', ['assets/chunk.1.css']);
+    writeIndex(`<link rel="stylesheet" href="/assets/rodnev.css"/>`);
+    await build();
+    assert.equal(
+      readIndex(),
+      `<link rel="stylesheet" href="/assets/rodnev.css"/>\n<link rel="stylesheet" href="/assets/chunk.1.css"/>`
+    );
+  });
+
+  test('uses same rootURL as vendor.js', async function (assert) {
+    buildResult.entrypoints.set('app', ['assets/chunk.1.js']);
+    writeIndex(`<script src="https://cdn.com/1234/assets/vendor.js"></script>`);
+    await build();
+    assert.equal(
+      readIndex(),
+      `<script src="https://cdn.com/1234/assets/vendor.js"></script>\n<script src="https://cdn.com/1234/assets/chunk.1.js"></script>`
+    );
+  });
+
+  test('uses same rootURL as vendor.css', async function (assert) {
+    buildResult.entrypoints.set('app', ['assets/chunk.1.css']);
+    writeIndex(`<link rel="stylesheet" href="https://cdn.com/1234/assets/vendor.css"/>`);
+    await build();
+    assert.equal(
+      readIndex(),
+      `<link rel="stylesheet" href="https://cdn.com/1234/assets/vendor.css"/>\n<link rel="stylesheet" href="https://cdn.com/1234/assets/chunk.1.css"/>`
+    );
+  });
+});

--- a/packages/ember-auto-import/ts/tests/inserter-test.ts
+++ b/packages/ember-auto-import/ts/tests/inserter-test.ts
@@ -16,9 +16,15 @@ Qmodule('inserter', function (hooks) {
   let publicAssetURL: string | undefined;
   let bundleConfig: BundleConfig;
   let buildResult: BuildResult;
+  let insertScriptsAt: string | undefined;
+  let insertStylesAt: string | undefined;
 
   async function build() {
-    let inserter = new Inserter(new UnwatchedDir(upstream), { buildResult } as Bundler, bundleConfig, publicAssetURL);
+    let inserter = new Inserter(new UnwatchedDir(upstream), { buildResult } as Bundler, bundleConfig, {
+      publicAssetURL,
+      insertScriptsAt,
+      insertStylesAt,
+    });
     builder = new broccoli.Builder(inserter);
     await builder.build();
   }

--- a/packages/ember-auto-import/ts/tests/splitter-test.ts
+++ b/packages/ember-auto-import/ts/tests/splitter-test.ts
@@ -54,7 +54,15 @@ Qmodule('splitter', function (hooks) {
       pack = new Package(stubAddonInstance(project.baseDir, options));
       let analyzer = new Analyzer(new UnwatchedDir(project.baseDir), pack);
       splitter = new Splitter({
-        bundles: new BundleConfig('thing' as any),
+        bundles: new BundleConfig({
+          vendor: {
+            js: 'assets/vendor.js',
+            css: 'assetes/vendor.css',
+          },
+          app: {
+            html: 'index.html',
+          },
+        }),
         analyzers: new Map([[analyzer, pack]]),
       });
       builder = new broccoli.Builder(analyzer);

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -23,24 +23,6 @@ registerHelper('join', function (list, connector) {
 });
 
 const entryTemplate = compile(`
-if (typeof document !== 'undefined') {
-  {{#if publicAssetURL}}
-  __webpack_public_path__ = '{{js-string-escape publicAssetURL}}';
-  {{else}}
-  {{!
-      locate the webpack lazy loaded chunks relative to the currently executing
-      script. The last <script> in DOM should be us, assuming that we are being
-      synchronously loaded, which is the normal thing to do. If people are doing
-      weirder things than that, they may need to explicitly set a publicAssetURL
-      instead.
-  }}
-  __webpack_public_path__ = (function(){
-    var scripts = document.querySelectorAll('script');
-    return scripts[scripts.length - 1].src.replace(/\\/[^/]*$/, '/');
-  })();
-  {{/if}}
-}
-
 module.exports = (function(){
   var d = _eai_d;
   var r = _eai_r;
@@ -156,7 +138,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
       target: `browserslist:${this.opts.browserslist}`,
       output: {
         path: join(this.outputPath, 'assets'),
-        publicPath: '',
+        publicPath: this.opts.publicAssetURL,
         filename: `chunk.[id].[chunkhash].js`,
         chunkFilename: `chunk.[id].[chunkhash].js`,
         libraryTarget: 'var',

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -302,9 +302,11 @@ export default class WebpackBundler extends Plugin implements Bundler {
         throw new Error(`unexpected webpack output: no entrypoint.assets`);
       }
 
-      this.opts.bundles.assertValidBundleName(id);
-
-      if (nonEmptyBundle(id, bundleDeps)) {
+      // our built-in bundles can be "empty" while still existing because we put
+      // setup code in them, so they get a special check for non-emptiness.
+      // Whereas any other bundle that was manually configured by the user
+      // should always be emitted.
+      if (!this.opts.bundles.isBuiltInBundleName(id) || nonEmptyBundle(id, bundleDeps)) {
         output.entrypoints.set(
           id,
           entrypointAssets.map(a => 'assets/' + a.name)

--- a/test-scenarios/custom-html-test.ts
+++ b/test-scenarios/custom-html-test.ts
@@ -1,0 +1,170 @@
+import { appScenarios } from './scenarios';
+import { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+import merge from 'lodash/merge';
+const { module: Qmodule, test } = QUnit;
+
+appScenarios
+  .map('custom-html', project => {
+    project.linkDependency('ember-auto-import', { baseDir: __dirname });
+    project.linkDependency('webpack', { baseDir: __dirname });
+
+    merge(project.files, {
+      'ember-cli-build.js': `
+        const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+        module.exports = function (defaults) {
+          let app = new EmberApp(defaults, {
+            autoImport: {
+              insertScriptsAt: 'auto-import-scripts',
+              webpack: {
+                entry: {
+                  'my-special-entrypoint': './lib/special.js',
+                }
+              }
+            },
+          });
+          app.import('vendor/my-vendor.js');
+          return app.toTree();
+        };
+      `,
+      app: {
+        'index.html': `
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8" />
+              <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+              <title>AppTemplate</title>
+              <meta name="description" content="" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+              {{content-for "head"}}
+
+              <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+              <link integrity="" rel="stylesheet" href="{{rootURL}}assets/@ef4/app-template.css" />
+
+              {{content-for "head-footer"}}
+            </head>
+            <body>
+              {{content-for "body"}}
+              <auto-import-scripts entrypoint="my-special-entrypoint"></auto-import-scripts>
+              <script src="{{rootURL}}assets/vendor.js"></script>
+              <auto-import-scripts entrypoint="app"></auto-import-scripts>
+              <script src="{{rootURL}}assets/@ef4/app-template.js"></script>
+
+              {{content-for "body-footer"}}
+            </body>
+          </html>
+        `,
+        templates: {
+          'application.hbs': `<div data-test="model">{{@model.aDep}}</div> <div data-test="vendor">{{@model.vendor}}</div>`,
+        },
+        routes: {
+          'application.js': `
+            import Route from '@ember/routing/route';
+            import aDep from 'a-dependency';
+            export default Route.extend({
+              model() {
+                return {
+                  aDep: aDep(),
+                  vendor: window.myVendorResult,
+                }
+              }
+            });
+          `,
+        },
+      },
+      lib: {
+        'special.js': `window.useMySpecialBundle = function() { return 'special bundle implementation is here' }`,
+      },
+      vendor: {
+        'my-vendor.js': `window.myVendorResult = useMySpecialBundle()`,
+      },
+      tests: {
+        'index.html': `
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <meta charset="utf-8" />
+              <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+              <title>AppTemplate Tests</title>
+              <meta name="description" content="" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+              {{content-for "head"}}
+              {{content-for "test-head"}}
+
+              <link rel="stylesheet" href="{{rootURL}}assets/vendor.css" />
+              <link rel="stylesheet" href="{{rootURL}}assets/@ef4/app-template.css" />
+              <link rel="stylesheet" href="{{rootURL}}assets/test-support.css" />
+
+
+              {{content-for "head-footer"}}
+              {{content-for "test-head-footer"}}
+            </head>
+            <body>
+              {{content-for "body"}}
+              {{content-for "test-body"}}
+
+              <div id="qunit"></div>
+              <div id="qunit-fixture">
+                <div id="ember-testing-container">
+                  <div id="ember-testing"></div>
+                </div>
+              </div>
+
+              <script src="/testem.js" integrity=""></script>
+              <auto-import-scripts entrypoint="my-special-entrypoint" data-custom="yes"></auto-import-scripts>
+              <script src="{{rootURL}}assets/vendor.js"></script>
+              <auto-import-scripts entrypoint="app"></auto-import-scripts>
+              <script src="{{rootURL}}assets/test-support.js"></script>
+              <auto-import-scripts entrypoint="tests"></auto-import-scripts>
+              <script src="{{rootURL}}assets/@ef4/app-template.js"></script>
+              <script src="{{rootURL}}assets/tests.js"></script>
+
+              {{content-for "body-footer"}}
+              {{content-for "test-body-footer"}}
+            </body>
+          </html>
+
+        `,
+        acceptance: {
+          'index-test.js': `
+            import { module, test } from 'qunit';
+            import { visit, currentURL } from '@ember/test-helpers';
+            import { setupApplicationTest } from 'ember-qunit';
+
+            module('Acceptance | index', function(hooks) {
+              setupApplicationTest(hooks);
+
+              test('visit /', async function (assert) {
+                await visit('/');
+                assert.equal(currentURL(), '/');
+                assert.equal(document.querySelector('[data-test="model"]').textContent.trim(), 'a-dep');
+                assert.equal(document.querySelector('[data-test="vendor"]').textContent.trim(), 'special bundle implementation is here');
+                assert.ok(document.querySelectorAll('[data-custom="yes"]').length > 0, 'found custom attribute');
+              });
+            });
+          `,
+        },
+      },
+    });
+    project.addDevDependency('a-dependency', {
+      files: {
+        'index.js': `module.exports = function() { return 'a-dep'}`,
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+
+      test('npm run test', async function (assert) {
+        let result = await app.execute('npm run test');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
+  });

--- a/test-scenarios/custom-html-test.ts
+++ b/test-scenarios/custom-html-test.ts
@@ -57,7 +57,7 @@ appScenarios
           </html>
         `,
         templates: {
-          'application.hbs': `<div data-test="model">{{@model.aDep}}</div> <div data-test="vendor">{{@model.vendor}}</div>`,
+          'application.hbs': `<div data-test="model">{{this.model.aDep}}</div> <div data-test="vendor">{{this.model.vendor}}</div>`,
         },
         routes: {
           'application.js': `


### PR DESCRIPTION
Allow the customization of inserted HTML via custom elements. Among other things, planning to fix #418, #420, #422, and #409 here.

Adds two new options:

```diff
export interface Options {
  exclude?: string[];
  alias?: { [fromName: string]: string };
  webpack?: Configuration;
  publicAssetURL?: string;
  styleLoaderOptions?: Record<string, unknown>;
  cssLoaderOptions?: Record<string, unknown>;
  forbidEval?: boolean;
  skipBabel?: { package: string; semverRange?: string }[];
  watchDependencies?: (string | string[])[];
+ insertScriptsAt? string;
+ insertStylesAt?: string;
}

```

When unset, we keep today's behavior, which inserts your app scripts after `vendor.js`, app styles after `vendor.css`, test scripts after `test-support.js` and test styles after `test-support.css`.

When set, these are the names of custom elements that appear in your HTML:

```js
autoImport: {
  insertScriptsAt: 'auto-import-scripts',
  insertStylesAt: 'auto-import-stylesheets',
}
```

```html
<auto-import-scripts entrypoint="app"  ></auto-import-scripts>
<auto-import-stylesheets entrypoint="app" ></auto-import-stylesheets>
```

The custom elements have one required attribute: `entrypoint` is the name of a webpack entry point. The default entry points that are always provided by ember-auto-import are named `"app"` and `"tests"`, and they contain everything auto-imported by your app and tests respectively. But you can define other entrypoints under `entry` in your webpack config, and use those names here.

During the build, your custom elements will be replaced with zero or more `<script>` or `<link>` elements, pointing at the built webpack bundles of the given type for the given entry point. Any attributes other than `entryPoint` on the custom element will be copied verbatim onto the resulting `<script>` or `<link>` elements.

This gives you control over both the location and the attributes of the elements ember-auto-import is inserting for you. 

This PR also unlocks a new capability: when you opt into controlling where the entrypoints will get inserted, you can also refer to *custom* entrypoints. For example:

```js
autoImport: {
  insertScriptsAt: 'auto-import-scripts',
  webpack: {
    entry: {
      polyfills: './lib/polyfills.js'
    }
  }
}
```

```js
// lib/polyfills.js
import "core-js/stable";
import "intl";
```

```html
<!-- our special polyfills entrypoint will run before vendor.js, which can be important! -->
<!-- it can also use "nomodule" to not run at all on modern browsers -->
<auto-import-script entrypoint="polyfills" nomodule></auto-import-script>
<script src="{{rootURL}}assets/vendor.js"></script>
<auto-import-script entrypoint="app"></auto-import-script>
<script src="{{rootURL}}assets/app.js"></script>
```