### PR TITLE
[v1.x] fix(analyzer): ignore type-only imports & exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31740,6 +31740,7 @@
         "webpack": "^4.43.0"
       },
       "devDependencies": {
+        "@babel/plugin-syntax-typescript": "^7.12.13",
         "@types/babel__core": "^7.0.4",
         "@types/babel__generator": "^7.0.1",
         "@types/babel__template": "^7.0.1",
@@ -44944,6 +44945,7 @@
       "version": "file:packages/ember-auto-import",
       "requires": {
         "@babel/core": "^7.1.6",
+        "@babel/plugin-syntax-typescript": "^7.12.13",
         "@babel/preset-env": "^7.10.2",
         "@babel/traverse": "^7.1.6",
         "@babel/types": "^7.1.6",

--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -58,6 +58,7 @@
     "webpack": "^4.43.0"
   },
   "devDependencies": {
+    "@babel/plugin-syntax-typescript": "^7.12.13",
     "@types/babel-core": "^6.25.5",
     "@types/babel__core": "^7.0.4",
     "@types/babel__generator": "^7.0.1",

--- a/packages/ember-auto-import/ts/analyzer.ts
+++ b/packages/ember-auto-import/ts/analyzer.ts
@@ -9,7 +9,7 @@ import { isEqual, flatten } from 'lodash';
 import type Package from './package';
 import symlinkOrCopy from 'symlink-or-copy';
 import { TransformOptions } from '@babel/core';
-import { Expression, File, TSType } from '@babel/types';
+import type { ExportNamedDeclaration, Expression, File, ImportDeclaration, TSType } from '@babel/types';
 import traverse from '@babel/traverse';
 
 makeDebug.formatters.m = (modules: Import[]) => {
@@ -77,6 +77,15 @@ export default class Analyzer extends Plugin {
   private paths: Map<string, Import[]> = new Map();
 
   private parse: undefined | ((source: string) => File);
+
+  // Ignores type-only imports & exports, which are erased from the final build
+  // output.
+  // TypeScript: `import type foo from 'foo'`
+  // Flow: `import typeof foo from 'foo'`
+  private erasedImportKinds: Set<ImportDeclaration['importKind']> = new Set(['type', 'typeof']);
+  // TypeScript: `export type foo from 'foo'`
+  // Flow: doesn't have type-only exports
+  private erasedExportKinds: Set<ExportNamedDeclaration['exportKind']> = new Set(['type']);
 
   constructor(inputTree: Node, private pack: Package, private treeType?: TreeType) {
     super([inputTree], {
@@ -231,6 +240,8 @@ export default class Analyzer extends Plugin {
         }
       },
       ImportDeclaration: path => {
+        if (this.erasedImportKinds.has(path.node.importKind)) return;
+
         imports.push({
           isDynamic: false,
           specifier: path.node.source.value,
@@ -240,15 +251,16 @@ export default class Analyzer extends Plugin {
         });
       },
       ExportNamedDeclaration: path => {
-        if (path.node.source) {
-          imports.push({
-            isDynamic: false,
-            specifier: path.node.source.value,
-            path: relativePath,
-            package: this.pack,
-            treeType: this.treeType,
-          });
-        }
+        if (!path.node.source) return;
+        if (this.erasedExportKinds.has(path.node.exportKind)) return;
+
+        imports.push({
+          isDynamic: false,
+          specifier: path.node.source.value,
+          path: relativePath,
+          package: this.pack,
+          treeType: this.treeType,
+        });
       },
     });
     return imports;

--- a/packages/ember-auto-import/ts/tests/analyzer-test.ts
+++ b/packages/ember-auto-import/ts/tests/analyzer-test.ts
@@ -175,6 +175,35 @@ Qmodule('analyzer', function (hooks) {
     assert.deepEqual(analyzer.imports, []);
   });
 
+  test('type-only imports ignored in created file', async function (assert) {
+    await builder.build();
+    let original = `
+      import type Foo from 'type-import';
+      import Bar from 'value-import';
+
+      export type { Qux } from 'type-re-export';
+      export { Baz } from 'value-re-export';
+    `;
+    outputFileSync(join(upstream, 'sample.js'), original);
+    await builder.build();
+    assert.deepEqual(analyzer.imports, [
+      {
+        isDynamic: false,
+        specifier: 'value-import',
+        path: 'sample.js',
+        package: pack,
+        treeType: undefined,
+      },
+      {
+        isDynamic: false,
+        specifier: 'value-re-export',
+        path: 'sample.js',
+        package: pack,
+        treeType: undefined,
+      },
+    ]);
+  });
+
   type LiteralExample = [string, string];
   type TemplateExample = [string, string[], string[]];
   function isLiteralExample(exp: LiteralExample | TemplateExample): exp is LiteralExample {

--- a/packages/ember-auto-import/ts/tests/analyzer-test.ts
+++ b/packages/ember-auto-import/ts/tests/analyzer-test.ts
@@ -24,7 +24,7 @@ Qmodule('analyzer', function (hooks) {
       get babelOptions() {
         babelOptionsWasAccessed = true;
         return {
-          plugins: [require.resolve('../../babel-plugin')],
+          plugins: [require.resolve('@babel/plugin-syntax-typescript'), require.resolve('../../babel-plugin')],
         };
       },
       babelMajorVersion: 6,


### PR DESCRIPTION
Backports #380 to [`v1.x`](https://github.com/ef4/ember-auto-import/tree/v1.x).