### PR TITLE
Add package.json repository field

### DIFF
--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -15,7 +15,10 @@
     "test": "tests"
   },
   "main": "js/index.js",
-  "repository": "https://github.com/ef4/ember-auto-import",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ef4/ember-auto-import.git"
+  },
   "scripts": {
     "compile": "tsc",
     "clean": "git clean -x -f",


### PR DESCRIPTION
So it shows up when `yarn outdated`

ref https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository