### PR TITLE
mixing of old and new analyzer patterns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30834,6 +30834,195 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/old-analyzer": {
+      "name": "ember-auto-import",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.1.0.tgz",
+      "integrity": "sha512-82iTXahaiswdOpMrosUzIvblpxCVd6jC1tvqKVd/wrUVVMj9tP3s5jqsVF7wKvf4im8ZjGkkuR8rMFU0CiqJNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.13.0",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/preset-env": "^7.10.2",
+        "@babel/traverse": "^7.1.6",
+        "@babel/types": "^7.1.6",
+        "@embroider/shared-internals": "^0.40.0",
+        "babel-loader": "^8.0.6",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.2.1",
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-plugin": "^4.0.0",
+        "broccoli-source": "^3.0.0",
+        "css-loader": "^5.2.0",
+        "debug": "^4.3.1",
+        "ember-cli-babel": "^7.0.0",
+        "fs-extra": "^6.0.1",
+        "fs-tree-diff": "^2.0.0",
+        "handlebars": "^4.3.1",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.19",
+        "mkdirp": "^0.5.1",
+        "parse5": "^6.0.1",
+        "resolve": "^1.20.0",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^2.6.2",
+        "semver": "^7.3.4",
+        "style-loader": "^2.0.0",
+        "symlink-or-copy": "^1.2.0",
+        "typescript-memoize": "^1.0.0-alpha.3",
+        "walk-sync": "^0.3.3"
+      },
+      "engines": {
+        "node": "12 || >= 14"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/code-frame": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/generator": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+      "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.15.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/helper-function-name": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+      "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-get-function-arity": "^7.14.5",
+        "@babel/template": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/helper-get-function-arity": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+      "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+      "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/highlight": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.5",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/template": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+      "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/parser": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/traverse": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+      "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.15.0",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-hoist-variables": "^7.14.5",
+        "@babel/helper-split-export-declaration": "^7.14.5",
+        "@babel/parser": "^7.15.0",
+        "@babel/types": "^7.15.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/@babel/types": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+      "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.14.9",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/old-analyzer/node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/old-analyzer/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -41485,6 +41674,7 @@
         "lodash-es": "^4.17.10",
         "moment": "^2.22.1",
         "newer-resolver": "npm:ember-resolver@^8.0.0",
+        "old-analyzer": "npm:ember-auto-import@2.1.0",
         "typescript-4": "npm:typescript@^4.1.2",
         "webpack": "^5.31.0"
       }
@@ -46578,6 +46768,7 @@
         "lodash-es": "^4.17.10",
         "moment": "^2.22.1",
         "newer-resolver": "npm:ember-resolver@^8.0.0",
+        "old-analyzer": "npm:ember-auto-import@2.1.0",
         "qunit": "^2.6.1",
         "scenario-tester": "^1.0.0",
         "ts-node": "^9.1.1",
@@ -71446,6 +71637,163 @@
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
+        }
+      }
+    },
+    "old-analyzer": {
+      "version": "npm:ember-auto-import@2.1.0",
+      "resolved": "https://registry.npmjs.org/ember-auto-import/-/ember-auto-import-2.1.0.tgz",
+      "integrity": "sha512-82iTXahaiswdOpMrosUzIvblpxCVd6jC1tvqKVd/wrUVVMj9tP3s5jqsVF7wKvf4im8ZjGkkuR8rMFU0CiqJNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.6",
+        "@babel/plugin-proposal-class-properties": "^7.13.0",
+        "@babel/plugin-proposal-decorators": "^7.13.5",
+        "@babel/preset-env": "^7.10.2",
+        "@babel/traverse": "^7.1.6",
+        "@babel/types": "^7.1.6",
+        "@embroider/shared-internals": "^0.40.0",
+        "babel-loader": "^8.0.6",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-htmlbars-inline-precompile": "^5.2.1",
+        "babel-plugin-syntax-dynamic-import": "^6.18.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-merge-trees": "^4.2.0",
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-plugin": "^4.0.0",
+        "broccoli-source": "^3.0.0",
+        "css-loader": "^5.2.0",
+        "debug": "^4.3.1",
+        "ember-cli-babel": "^7.0.0",
+        "fs-extra": "^6.0.1",
+        "fs-tree-diff": "^2.0.0",
+        "handlebars": "^4.3.1",
+        "js-string-escape": "^1.0.1",
+        "lodash": "^4.17.19",
+        "mkdirp": "^0.5.1",
+        "parse5": "^6.0.1",
+        "resolve": "^1.20.0",
+        "resolve-package-path": "^3.1.0",
+        "rimraf": "^2.6.2",
+        "semver": "^7.3.4",
+        "style-loader": "^2.0.0",
+        "symlink-or-copy": "^1.2.0",
+        "typescript-memoize": "^1.0.0-alpha.3",
+        "walk-sync": "^0.3.3"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+          "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.14.5",
+            "@babel/template": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+          "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+          "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/template": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+          "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },

--- a/packages/ember-auto-import/ts/analyzer-plugin.ts
+++ b/packages/ember-auto-import/ts/analyzer-plugin.ts
@@ -5,6 +5,9 @@ import { ImportSyntax, serialize } from './analyzer-syntax';
 interface State {
   imports: ImportSyntax[];
   handled: WeakSet<t.CallExpression>;
+  opts: {
+    imports?: ImportSyntax[];
+  };
 }
 
 // Ignores type-only imports & exports, which are erased from the final build
@@ -23,7 +26,7 @@ function analyzerPlugin(babel: typeof Babel) {
     visitor: {
       Program: {
         enter(_path: NodePath<t.Program>, state: State) {
-          state.imports = [];
+          state.imports = state.opts.imports || [];
           state.handled = new WeakSet();
         },
         exit(path: NodePath<t.Program>, state: State) {

--- a/packages/ember-auto-import/ts/index.ts
+++ b/packages/ember-auto-import/ts/index.ts
@@ -2,7 +2,6 @@ import AutoImport from './auto-import';
 import type { Node } from 'broccoli-node-api';
 // @ts-ignore
 import pkg from '../package';
-import { isDeepAddonInstance } from '@embroider/shared-internals';
 
 module.exports = {
   name: pkg.name,
@@ -31,17 +30,14 @@ module.exports = {
           treeType = options.treeType;
         }
 
-        return AutoImport.lookup(this).analyze(tree, this, treeType);
+        return AutoImport.lookup(this).analyze(tree, this, treeType, true);
       },
     });
   },
 
   included(...args: unknown[]) {
     this._super.included.apply(this, ...args);
-    AutoImport.lookup(this).installBabelPlugin(this);
-    if (!isDeepAddonInstance(this)) {
-      AutoImport.lookup(this).included(this);
-    }
+    AutoImport.lookup(this).included(this);
   },
 
   // this exists to be called by @embroider/addon-shim

--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -68,6 +68,8 @@ export default class Package {
   private _options: any;
   private _parent: Project | AddonInstance;
   private _hasBabelDetails = false;
+  private _babelMajorVersion?: number;
+  private _babelOptions: any;
   private _emberCLIBabelExtensions?: string[];
   private autoImportOptions: Options | undefined;
   private isDeveloping: boolean;
@@ -114,9 +116,21 @@ export default class Package {
     if (this._hasBabelDetails) {
       return;
     }
-    let { extensions } = this.buildBabelOptions(this._parent, this._options);
+    let { babelOptions, extensions, version } = this.buildBabelOptions(this._parent, this._options);
     this._emberCLIBabelExtensions = extensions;
+    this._babelOptions = babelOptions;
+    this._babelMajorVersion = version;
     this._hasBabelDetails = true;
+  }
+
+  get babelOptions(): TransformOptions {
+    this._ensureBabelDetails();
+    return this._babelOptions;
+  }
+
+  get babelMajorVersion() {
+    this._ensureBabelDetails();
+    return this._babelMajorVersion;
   }
 
   @Memoize()

--- a/packages/ember-auto-import/ts/tests/analyzer-test.ts
+++ b/packages/ember-auto-import/ts/tests/analyzer-test.ts
@@ -41,7 +41,7 @@ Qmodule('analyzer', function (hooks) {
       ],
     };
     let transpiled = broccoliBabel(new UnwatchedDir(upstream), babelConfig);
-    analyzer = new Analyzer(transpiled, pack);
+    analyzer = new Analyzer(transpiled, pack, undefined, true);
     builder = new broccoli.Builder(analyzer);
   });
 

--- a/packages/ember-auto-import/ts/tests/splitter-test.ts
+++ b/packages/ember-auto-import/ts/tests/splitter-test.ts
@@ -66,7 +66,7 @@ Qmodule('splitter', function (hooks) {
           require('../../babel-plugin'),
         ],
       });
-      let analyzer = new Analyzer(transpiled, pack);
+      let analyzer = new Analyzer(transpiled, pack, undefined, true);
       splitter = new Splitter({
         bundles: new BundleConfig({
           vendor: {

--- a/test-scenarios/package.json
+++ b/test-scenarios/package.json
@@ -24,6 +24,7 @@
     "fs-extra": "^6.0.1",
     "leader-v1": "npm:ember-auto-import@1.7",
     "leader-v2": "npm:ember-auto-import@1.11",
+    "old-analyzer": "npm:ember-auto-import@2.1.0",
     "ember-cli-babel-older": "npm:ember-cli-babel@7.11.1",
     "ember-cli-lts": "npm:ember-cli@~3.4.0",
     "ember-cli-latest": "npm:ember-cli@latest",


### PR DESCRIPTION
The changes in #440 can break when an addon is using a 2.x copy of ember-auto-import that predates the changes. The problem is that older copies will run their own `included` hook which does not install the babel plugin.