### PR TITLE
Mark test-scenarios package as private

### DIFF
--- a/test-scenarios/package.json
+++ b/test-scenarios/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@ef4/test-scenarios",
   "version": "0.0.0",
+  "private": true,
   "dependencies": {
     "@types/qunit": "^2.11.1",
     "qunit": "^2.6.1",


### PR DESCRIPTION
While reviewing how `scenario-tester` worked, I was poking around in this repo's wiring and was momentarily confused (thinking that this package was actually published, which is obviously silly now that I think about it...). 
