### PR TITLE
Support .mjs extensions

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -160,7 +160,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
         },
       },
       resolve: {
-        extensions: ['.js', '.ts', '.json'],
+        extensions: ['.js', '.mjs', '.ts', '.json'],
         mainFields: ['browser', 'module', 'main'],
         alias: Object.assign({}, ...[...this.opts.packages].map(pkg => pkg.aliases).filter(Boolean)),
       },


### PR DESCRIPTION
If I'm reading this right, https://webpack.js.org/guides/ecma-script-modules/

*.mjs is supported (as modules) no matter what?