### PR TITLE
Prevent loss of characters in case of false end-partial-match

### DIFF
--- a/packages/ember-auto-import/ts/analyzer-syntax.ts
+++ b/packages/ember-auto-import/ts/analyzer-syntax.ts
@@ -181,10 +181,11 @@ class Deserializer {
             meta: state.meta.join(''),
           };
         } else {
-          // partial match failed to complete
+          // partial match failed to complete, so we need to replace the partial
+          // marker match we stripped off the last chunk
           this.state = {
             type: 'finding-end',
-            meta: state.meta,
+            meta: [...state.meta, MARKER.slice(0, state.partialMatch)],
           };
           return this.consumeChunk(chunk);
         }


### PR DESCRIPTION
Attempted fix for https://github.com/ef4/ember-auto-import/issues/449

I believe I ran into the same issue, and built on the debugging that @vlascik had done.  I don't have a deep understanding of how this code fits into the overall build pipeline, but was able to wrap my head around the code in this module enough to propose a fix.

This addresses the case where we found a partial match for `MARKER` at the end of the last chunk, but now that we're looking in the next chunk we've realized it wasn't really a match.  The fix is to make sure the characters we sliced off of the last chunk don't get lost.