### PR TITLE
package.json: Add `directory` metadata

### DIFF
--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -15,7 +15,11 @@
     "test": "tests"
   },
   "main": "js/index.js",
-  "repository": "https://github.com/ef4/ember-auto-import",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ef4/ember-auto-import",
+    "directory": "packages/ember-auto-import"
+  },
   "scripts": {
     "compile": "tsc",
     "clean": "git clean -x -f",


### PR DESCRIPTION
This allows other tooling to find the package within the monorepo. e.g. renovatebot should then be able to find the changelog file and display it when opening dependency update PRs.

/cc @ef4 
