### PR TITLE
Avoid EBADF on ReadStream early close in Node 12

### DIFF
--- a/packages/ember-auto-import/ts/analyzer-syntax.ts
+++ b/packages/ember-auto-import/ts/analyzer-syntax.ts
@@ -100,13 +100,20 @@ class Deserializer {
   // keeps consuming chunks until we read null (meaning no buffered data
   // available) or the state machine decides to stop
   private run() {
+    if (this.state.type === 'done') {
+      return;
+    }
+
     let chunk: string | null;
     // setting the read size bigger than the marker length is important. We can
     // deal with a marker split between two chunks, but not three or more.
     while (null !== (chunk = this.source.read(1024))) {
       this.consumeChunk(chunk);
+
+      // False positive for TS2367, see https://github.com/microsoft/TypeScript/issues/9998
+      // @ts-ignore
       if (this.state.type === 'done') {
-        this.source.destroy();
+        this.finish();
         break;
       }
     }

--- a/packages/ember-auto-import/ts/analyzer.ts
+++ b/packages/ember-auto-import/ts/analyzer.ts
@@ -124,8 +124,14 @@ export default class Analyzer extends Funnel {
     let meta: ImportSyntax[];
     if (this.supportsFastAnalyzer) {
       debug(`updating imports for ${relativePath}`);
-      let stream = createReadStream(join(this.inputPaths[0], relativePath), { encoding: 'utf8' });
+      let stream = createReadStream(join(this.inputPaths[0], relativePath), {
+        encoding: 'utf8',
+        autoClose: false,
+        // @ts-ignore
+        emitClose: true, // Needs to be specified for Node 12, as default is false
+      });
       meta = await deserialize(stream);
+      stream.destroy();
     } else {
       debug(`updating imports (the slower way) for ${relativePath}`);
       let parse = await this.parser();

--- a/packages/ember-auto-import/ts/analyzer.ts
+++ b/packages/ember-auto-import/ts/analyzer.ts
@@ -126,12 +126,10 @@ export default class Analyzer extends Funnel {
       debug(`updating imports for ${relativePath}`);
       let stream = createReadStream(join(this.inputPaths[0], relativePath), {
         encoding: 'utf8',
-        autoClose: false,
         // @ts-ignore
         emitClose: true, // Needs to be specified for Node 12, as default is false
       });
       meta = await deserialize(stream);
-      stream.destroy();
     } else {
       debug(`updating imports (the slower way) for ${relativePath}`);
       let parse = await this.parser();


### PR DESCRIPTION
On Node <= 14, there seems to be a potential for EBADF to get raised
after a ReadStream has been closed (https://github.com/nodejs/node/issues/25335)

We can workaround this causing problems by finishing the deserializer's operations
rather than calling 'destroy' on the ReadStream mid-read. This way the Promise gets
resolved with the result before a potential EBADF can occur.

Then we can simply destroy the ReadStream explicitly when we know we're done with it.

Also made sure to add `emitClose` for Node 12, which is `false` by default until Node 14 and might be causing the close event handlers not to get processed. (Though TypeScript seemed upset about adding that, despite it being a documented option for `createReadStream`, so had to slap on a `// @ts-ignore`. Let me know if there's a way to fix that.)

Seems to fix #464, as I haven't been able to reproduce the EBADF after re-running a couple dozen times (where previously I would get it 25-50% of the time)