### PR TITLE
concat mixed configuration for webpack externals

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -1,4 +1,10 @@
-import type { Configuration, Compiler, RuleSetRule, Stats } from 'webpack';
+import type {
+  Configuration,
+  Compiler,
+  RuleSetRule,
+  Stats,
+  ExternalItem,
+} from 'webpack';
 import { join, dirname } from 'path';
 import { mergeWith, flatten, zip } from 'lodash';
 import { writeFileSync, realpathSync } from 'fs';
@@ -195,7 +201,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
         ],
       },
       node: false,
-      externals: this.externalsHandler,
+      externals: [this.externalsHandler],
     };
 
     mergeConfig(
@@ -242,7 +248,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
   }
 
   @Memoize()
-  private get externalsHandler(): Configuration['externals'] {
+  private get externalsHandler(): ExternalItem {
     let packageCache = PackageCache.shared(
       'ember-auto-import',
       this.opts.appRoot
@@ -435,6 +441,14 @@ export function mergeConfig(dest: Configuration, ...srcs: Configuration[]) {
 function combine(objValue: any, srcValue: any, key: string) {
   if (key === 'noParse') {
     return eitherPattern(objValue, srcValue);
+  }
+
+  if (key === 'externals') {
+    if (typeof objValue === 'undefined') {
+      return [srcValue];
+    } else if (!Array.isArray(srcValue)) {
+      return [...objValue, srcValue];
+    }
   }
 
   // arrays concat

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -195,7 +195,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
         ],
       },
       node: false,
-      externals: [this.externalsHandler],
+      externals: this.externalsHandler,
     };
 
     mergeConfig(
@@ -242,10 +242,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
   }
 
   @Memoize()
-  private get externalsHandler(): Extract<
-    Configuration['externals'],
-    (params: any, callback: any) => void
-  > {
+  private get externalsHandler(): Configuration['externals'] {
     let packageCache = PackageCache.shared(
       'ember-auto-import',
       this.opts.appRoot
@@ -441,11 +438,7 @@ function combine(objValue: any, srcValue: any, key: string) {
   }
 
   if (key === 'externals') {
-    if (typeof objValue === 'undefined') {
-      return [srcValue];
-    } else if (!Array.isArray(srcValue)) {
-      return [...objValue, srcValue];
-    }
+    return [srcValue, objValue].flat();
   }
 
   // arrays concat

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -1,10 +1,4 @@
-import type {
-  Configuration,
-  Compiler,
-  RuleSetRule,
-  Stats,
-  ExternalItem,
-} from 'webpack';
+import type { Configuration, Compiler, RuleSetRule, Stats } from 'webpack';
 import { join, dirname } from 'path';
 import { mergeWith, flatten, zip } from 'lodash';
 import { writeFileSync, realpathSync } from 'fs';
@@ -248,7 +242,10 @@ export default class WebpackBundler extends Plugin implements Bundler {
   }
 
   @Memoize()
-  private get externalsHandler(): ExternalItem {
+  private get externalsHandler(): Extract<
+    Configuration['externals'],
+    (params: any, callback: any) => void
+  > {
     let packageCache = PackageCache.shared(
       'ember-auto-import',
       this.opts.appRoot

--- a/packages/ember-auto-import/tsconfig.json
+++ b/packages/ember-auto-import/tsconfig.json
@@ -1,12 +1,16 @@
 {
   "include": ["./ts/**/*.ts"],
   "compilerOptions": {
-    "lib": ["es7", "dom"],
+    "lib": ["es2020", "dom"],
     "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./js",
-    "typeRoots": ["node_modules/@types", "../../types", "../../node_modules/@types"],
+    "typeRoots": [
+      "node_modules/@types",
+      "../../types",
+      "../../node_modules/@types"
+    ],
     "esModuleInterop": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
This is a fix for https://github.com/ef4/ember-auto-import/issues/412
Now we are merging externals correctly and using [combining-syntaxes](https://webpack.js.org/configuration/externals/#combining-syntaxes)