### PR TITLE
fix test linkage

### DIFF
--- a/test-scenarios/package.json
+++ b/test-scenarios/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@ef4/addon-template": "*",
     "@ef4/app-template": "*",
-    "ember-auto-import": "^1.11.3",
+    "ember-auto-import": "^1.12.0",
     "ember-cli-2.18": "npm:ember-cli@~2.18.0",
     "ember-cli-babel6": "npm:ember-cli-babel@^6.6.0",
     "ember-cli-latest": "npm:ember-cli@latest",


### PR DESCRIPTION
On the 1.x branch, tests aren't really testing the current version.

We have assertions about this on main, but this backports branch doesn't catch this problem.