### PR TITLE
fastboot css fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,6 +4077,42 @@
         "ajv": ">=5.0.0"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -26885,6 +26921,73 @@
         "node": ">=4"
       }
     },
+    "node_modules/mini-css-extract-plugin": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.5.2.tgz",
+      "integrity": "sha512-Lwgq9qLNyBK6yNLgzssXnq4r2+mB9Mz3cJWlM8kseysHIvTicFhDNimFgY94jjqlwhNzLPsq8wv4X+vOHtMdYA==",
+      "dependencies": {
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+      "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/mini-css-extract-plugin/node_modules/schema-utils": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.8.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -29535,7 +29638,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -34225,6 +34327,7 @@
         "handlebars": "^4.3.1",
         "js-string-escape": "^1.0.1",
         "lodash": "^4.17.19",
+        "mini-css-extract-plugin": "^2.5.2",
         "parse5": "^6.0.1",
         "resolve": "^1.20.0",
         "resolve-package-path": "^3.1.0",
@@ -38887,6 +38990,32 @@
       "dev": true,
       "requires": {}
     },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        }
+      }
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -43519,6 +43648,7 @@
         "handlebars": "^4.3.1",
         "js-string-escape": "^1.0.1",
         "lodash": "^4.17.19",
+        "mini-css-extract-plugin": "^2.5.2",
         "npm-run-all": "^4.1.5",
         "parse5": "^6.0.1",
         "prettier": "^2.5.1",
@@ -57987,6 +58117,51 @@
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
+    "mini-css-extract-plugin": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.5.2.tgz",
+      "integrity": "sha512-Lwgq9qLNyBK6yNLgzssXnq4r2+mB9Mz3cJWlM8kseysHIvTicFhDNimFgY94jjqlwhNzLPsq8wv4X+vOHtMdYA==",
+      "requires": {
+        "schema-utils": "^4.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.9.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
+          "integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+          "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.3"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "schema-utils": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+          "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "ajv": "^8.8.0",
+            "ajv-formats": "^2.1.1",
+            "ajv-keywords": "^5.0.0"
+          }
+        }
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -60087,8 +60262,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "requireindex": {
       "version": "1.2.0",

--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -55,6 +55,7 @@
     "handlebars": "^4.3.1",
     "js-string-escape": "^1.0.1",
     "lodash": "^4.17.19",
+    "mini-css-extract-plugin": "^2.5.2",
     "parse5": "^6.0.1",
     "resolve": "^1.20.0",
     "resolve-package-path": "^3.1.0",

--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -149,6 +149,7 @@ export default class AutoImport implements AutoImportSharedAPI {
       browserslist: this.rootPackage.browserslist(),
       publicAssetURL: this.rootPackage.publicAssetURL(),
       webpack,
+      hasFastboot: this.rootPackage.isFastBootEnabled,
     });
   }
 

--- a/packages/ember-auto-import/ts/bundler.ts
+++ b/packages/ember-auto-import/ts/bundler.ts
@@ -20,6 +20,7 @@ export interface BundlerOptions {
   publicAssetURL: string | undefined;
   browserslist: string;
   webpack: typeof webpack;
+  hasFastboot: boolean;
 }
 
 export interface BuildResult {

--- a/packages/ember-auto-import/ts/inserter.ts
+++ b/packages/ember-auto-import/ts/inserter.ts
@@ -68,11 +68,15 @@ export class Inserter extends Plugin {
       let assets = this.bundler.buildResult.entrypoints.get('app');
       if (assets) {
         for (let asset of assets) {
-          fastbootInfo.vendorFiles.push(asset);
+          if (asset.endsWith('.js')) {
+            fastbootInfo.vendorFiles.push(asset);
+          }
         }
       }
       for (let asset of this.bundler.buildResult.lazyAssets) {
-        fastbootInfo.vendorFiles.push(asset);
+        if (asset.endsWith('.js')) {
+          fastbootInfo.vendorFiles.push(asset);
+        }
       }
       writeJSONSync(join(this.outputPath, 'package.json'), fastbootInfo.pkg);
     }

--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -32,6 +32,7 @@ export interface Options {
   publicAssetURL?: string;
   styleLoaderOptions?: Record<string, unknown>;
   cssLoaderOptions?: Record<string, unknown>;
+  miniCssExtractPluginOptions?: Record<string, unknown>;
   forbidEval?: boolean;
   skipBabel?: { package: string; semverRange?: string }[];
   watchDependencies?: (string | string[])[];
@@ -147,7 +148,7 @@ export default class Package {
   get isFastBootEnabled() {
     return (
       process.env.FASTBOOT_DISABLED !== 'true' &&
-      !!this._parent.addons.find((addon) => addon.name === 'ember-cli-fastboot')
+      this._parent.addons.some((addon) => addon.name === 'ember-cli-fastboot')
     );
   }
 
@@ -418,6 +419,13 @@ export default class Package {
   get cssLoaderOptions(): Record<string, unknown> | undefined {
     // only apps (not addons) are allowed to set this
     return this.isAddon ? undefined : this.autoImportOptions?.cssLoaderOptions;
+  }
+
+  get miniCssExtractPluginOptions(): Record<string, unknown> | undefined {
+    // only apps (not addons) are allowed to set this
+    return this.isAddon
+      ? undefined
+      : this.autoImportOptions?.miniCssExtractPluginOptions;
   }
 
   get forbidsEval(): boolean {

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -224,11 +224,13 @@ export default class WebpackBundler extends Plugin implements Bundler {
     if (this.opts.environment === 'production' || this.opts.hasFastboot) {
       return {
         loader: MiniCssExtractPlugin.loader,
-        plugin: new MiniCssExtractPlugin(
-          [...this.opts.packages].find(
+        plugin: new MiniCssExtractPlugin({
+          filename: `chunk.[id].[chunkhash].css`,
+          chunkFilename: `chunk.[id].[chunkhash].css`,
+          ...[...this.opts.packages].find(
             (pkg) => pkg.miniCssExtractPluginOptions
-          )?.miniCssExtractPluginOptions
-        ),
+          )?.miniCssExtractPluginOptions,
+        }),
       };
     } else
       return {


### PR DESCRIPTION
Under fastboot, CSS needs to always be in separate CSS files, not riding along inside the JS and being appended to the DOM by JS.

This is also a better production default, and that's what embroider does, so we're going to match the embroider behavior here and use separate CSS files in production builds.