### PR TITLE
don't let broccoli-asset-rev mess with css chunks

### DIFF
--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -208,7 +208,7 @@ export default class AutoImport implements AutoImportSharedAPI {
   // have their own webpack-generated hashes and (2) the runtime loader code
   // can't easily be told about broccoli-asset-rev's hashes.
   private configureFingerprints(host: AppInstance) {
-    let patterns = ['assets/chunk.*.js', 'assets/chunk..*.css'];
+    let patterns = ['assets/chunk.*.js', 'assets/chunk.*.css'];
     if (!host.options.fingerprint) {
       host.options.fingerprint = {};
     }

--- a/packages/ember-auto-import/ts/auto-import.ts
+++ b/packages/ember-auto-import/ts/auto-import.ts
@@ -208,14 +208,16 @@ export default class AutoImport implements AutoImportSharedAPI {
   // have their own webpack-generated hashes and (2) the runtime loader code
   // can't easily be told about broccoli-asset-rev's hashes.
   private configureFingerprints(host: AppInstance) {
-    let pattern = 'assets/chunk.*.js';
+    let patterns = ['assets/chunk.*.js', 'assets/chunk..*.css'];
     if (!host.options.fingerprint) {
       host.options.fingerprint = {};
     }
     if (!('exclude' in host.options.fingerprint)) {
-      host.options.fingerprint.exclude = [pattern];
+      host.options.fingerprint.exclude = patterns;
     } else {
-      host.options.fingerprint.exclude.push(pattern);
+      for (let pattern of patterns) {
+        host.options.fingerprint.exclude.push(pattern);
+      }
     }
   }
 }


### PR DESCRIPTION
We already have code to defend our JS chunks from getting renamed by broccoli-asset-rev, but we need the same for any emitted CSS chunks.

Fixes #493.