### PR TITLE
Allow disabling sourcemaps when forbidEval is set (v1.x)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7747,6 +7747,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.0.tgz",
       "integrity": "sha512-G4Zc8HngZIdASyQOiz/9H/0Gjc2F02EFwhWF4wiueaI+/FBrM9Ixj6Prno/1aiLIYcN0JvRC3oytN9uOVonTww==",
+      "dev": true,
       "dependencies": {
         "broccoli-node-api": "^1.6.0"
       },
@@ -21148,9 +21149,9 @@
       }
     },
     "node_modules/fixturify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-2.1.0.tgz",
-      "integrity": "sha512-gHq6UCv8DE91EpiaRSzrmvLoRvFOBzI961IQ3gXE5wfmMM1TtApDcZAonG2hnp6GJrVFCxHwP01wSw9VQJiJ1w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-2.1.1.tgz",
+      "integrity": "sha512-SRgwIMXlxkb6AUgaVjIX+jCEqdhyXu9hah7mcK+lWynjKtX73Ux1TDv71B7XyaQ+LJxkYRHl5yCL8IycAvQRUw==",
       "dependencies": {
         "@types/fs-extra": "^8.1.0",
         "@types/minimatch": "^3.0.3",
@@ -21166,7 +21167,7 @@
     "node_modules/fixturify-project": {
       "version": "2.1.1",
       "resolved": "git+ssh://git@github.com/ef4/node-fixturify-project.git#ce267a90824675d9eb34459df625dcfcceec5491",
-      "integrity": "sha512-wn1kClYee1K8Gu+o57tF/QHukfmFbx8PrayvgzSNOLL76eJ9l7mjRhdJYVsBrNNmuunuCUzpbQB3B1EBO6E9Kg==",
+      "integrity": "sha512-kaLagFGWucGnQ+cW1TRHnPvhVR4Jhj6JzDk3NqVJDwDBljz1W4VX7ktworrgVeTStEKDDhczeI8vCzdOJIYT/A==",
       "license": "MIT",
       "dependencies": {
         "fixturify": "^2.1.0",
@@ -21201,9 +21202,9 @@
       }
     },
     "node_modules/fixturify/node_modules/@types/fs-extra": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.1.tgz",
-      "integrity": "sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.2.tgz",
+      "integrity": "sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -32015,7 +32016,7 @@
       "devDependencies": {
         "@ef4/addon-template": "*",
         "@ef4/app-template": "*",
-        "ember-auto-import": "^1.12.0",
+        "ember-auto-import": "^1.12.1",
         "ember-cli": "git+https://github.com/ember-cli/ember-cli#master",
         "ember-cli-2.18": "npm:ember-cli@~2.18.0",
         "ember-cli-babel6": "npm:ember-cli-babel@^6.6.0",
@@ -35599,7 +35600,7 @@
         "@ef4/app-template": "*",
         "@ef4/test-support": "*",
         "@types/qunit": "^2.11.1",
-        "ember-auto-import": "^1.12.0",
+        "ember-auto-import": "^1.12.1",
         "ember-cli": "git+https://github.com/ember-cli/ember-cli#master",
         "ember-cli-2.18": "npm:ember-cli@~2.18.0",
         "ember-cli-babel6": "npm:ember-cli-babel@^6.6.0",
@@ -41306,6 +41307,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-source/-/broccoli-source-3.0.0.tgz",
       "integrity": "sha512-G4Zc8HngZIdASyQOiz/9H/0Gjc2F02EFwhWF4wiueaI+/FBrM9Ixj6Prno/1aiLIYcN0JvRC3oytN9uOVonTww==",
+      "dev": true,
       "requires": {
         "broccoli-node-api": "^1.6.0"
       }
@@ -53497,9 +53499,9 @@
       }
     },
     "fixturify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-2.1.0.tgz",
-      "integrity": "sha512-gHq6UCv8DE91EpiaRSzrmvLoRvFOBzI961IQ3gXE5wfmMM1TtApDcZAonG2hnp6GJrVFCxHwP01wSw9VQJiJ1w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fixturify/-/fixturify-2.1.1.tgz",
+      "integrity": "sha512-SRgwIMXlxkb6AUgaVjIX+jCEqdhyXu9hah7mcK+lWynjKtX73Ux1TDv71B7XyaQ+LJxkYRHl5yCL8IycAvQRUw==",
       "requires": {
         "@types/fs-extra": "^8.1.0",
         "@types/minimatch": "^3.0.3",
@@ -53510,9 +53512,9 @@
       },
       "dependencies": {
         "@types/fs-extra": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.1.tgz",
-          "integrity": "sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==",
+          "version": "8.1.2",
+          "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.2.tgz",
+          "integrity": "sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==",
           "requires": {
             "@types/node": "*"
           }
@@ -53542,7 +53544,7 @@
     },
     "fixturify-project": {
       "version": "git+ssh://git@github.com/ef4/node-fixturify-project.git#ce267a90824675d9eb34459df625dcfcceec5491",
-      "integrity": "sha512-wn1kClYee1K8Gu+o57tF/QHukfmFbx8PrayvgzSNOLL76eJ9l7mjRhdJYVsBrNNmuunuCUzpbQB3B1EBO6E9Kg==",
+      "integrity": "sha512-kaLagFGWucGnQ+cW1TRHnPvhVR4Jhj6JzDk3NqVJDwDBljz1W4VX7ktworrgVeTStEKDDhczeI8vCzdOJIYT/A==",
       "from": "fixturify-project@ef4/node-fixturify-project#ce267a90824675d9eb34459df625dcfcceec5491",
       "requires": {
         "fixturify": "^2.1.0",

--- a/packages/ember-auto-import/ts/bundler.ts
+++ b/packages/ember-auto-import/ts/bundler.ts
@@ -76,8 +76,12 @@ export default class Bundler extends Plugin {
 
   get bundlerHook(): BundlerHook {
     if (!this.cachedBundlerHook) {
+      const internalWebpackConfig: any = {};
+      if ([...this.options.packages.values()].find(pkg => pkg.forbidsEval)) {
+        internalWebpackConfig.devtool = 'source-map';
+      }
       let extraWebpackConfig = mergeWith(
-        {},
+        internalWebpackConfig,
         ...[...this.options.packages.values()].map(pkg => pkg.webpackConfig),
         (objValue: any, srcValue: any) => {
           // arrays concat
@@ -86,9 +90,6 @@ export default class Bundler extends Plugin {
           }
         }
       );
-      if ([...this.options.packages.values()].find(pkg => pkg.forbidsEval)) {
-        extraWebpackConfig.devtool = 'source-map';
-      }
       debug('extraWebpackConfig %j', extraWebpackConfig);
       this.cachedBundlerHook = new WebpackBundler(
         this.options.bundles,


### PR DESCRIPTION
Fixes #444 for 1.x

I went with @ef4's advice to give precedence to the user's webpack config.

I tried to write a unit test for `Bundler.bundlerHook`, but the stubbing rabbit hole went too deep. Happy to try again if you have advice for how to test my change.

Aside:
When I tried to get local development set up for `tags/v1.12.1`, `npm i` would fail due to an integrity mismatch on ef4/node-fixturify-project. (See commit message for error log.) I healed the package-lock by deleting and re-adding the package, which did some minor bumps. I figure since you own both packages you can speak to the source & legitimacy of the integrity mismatch.