### PR TITLE
Adjust appRoot to account for dummy apps

### DIFF
--- a/packages/ember-auto-import/ts/package.ts
+++ b/packages/ember-auto-import/ts/package.ts
@@ -70,6 +70,7 @@ type Resolution =
 export default class Package {
   public name: string;
   public root: string;
+  private pkgRoot: string;
   public isAddon: boolean;
   private _options: any;
   private _parent: Project | AddonInstance;
@@ -97,14 +98,17 @@ export default class Package {
 
   constructor(child: AddonInstance) {
     this.name = child.parent.pkg.name;
-    this.root = child.parent.root;
 
     if (isDeepAddonInstance(child)) {
+      this.root = this.pkgRoot = child.parent.root;
       this.isAddon = true;
       this.isDeveloping = this.root === child.project.root;
       // This is the per-package options from ember-cli
       this._options = child.parent.options;
     } else {
+      // this can differ from child.parent.root because Dummy apps are terrible
+      this.root = join(child.project.configPath(), '..', '..');
+      this.pkgRoot = child.parent.root;
       this.isAddon = false;
       this.isDeveloping = true;
       this._options = child.app.options;
@@ -187,7 +191,7 @@ export default class Package {
       // avoiding `require` here because we don't want to go through the
       // require cache.
       this.pkgCache = JSON.parse(
-        readFileSync(join(this.root, 'package.json'), 'utf-8')
+        readFileSync(join(this.pkgRoot, 'package.json'), 'utf-8')
       );
       this.pkgGeneration = pkgGeneration;
     }

--- a/packages/ember-auto-import/ts/tests/splitter-test.ts
+++ b/packages/ember-auto-import/ts/tests/splitter-test.ts
@@ -476,6 +476,9 @@ function stubAddonInstance(
     name() {
       return 'my-project';
     },
+    configPath() {
+      return join(baseDir, 'config', 'environment');
+    },
   } as EmberCLIProject;
   let app = {
     env: 'development',


### PR DESCRIPTION
Dummy apps have a logical root that is different from their package root.

Mostly we are tracking the app root so that package resolution knows when devDependencies are relevant (they're relevant in the app and nowhere else). The classic build glosses over this distinction. But embroider cares and treats the dummy app as a distinct package, so if you get the app root wrong it can seed the shared PackageCache with the wrong value and cause the dummy app to not see its own devDependencies.

I think this is source of failures in https://github.com/simplabs/qunit-dom/pull/1423