### PR TITLE
Move Dynamic Template Import error to runtime instead of a build error

### DIFF
--- a/packages/ember-auto-import/ts/splitter.ts
+++ b/packages/ember-auto-import/ts/splitter.ts
@@ -141,12 +141,7 @@ export default class Splitter {
     }
 
     if (target.type === 'local') {
-      throw new Error(
-        `ember-auto-import does not support dynamic relative imports. "${leadingQuasi}" is relative. To make this work, you need to upgrade to Embroider. ` +
-          `The attempted import of '${imp.cookedQuasis.join(
-            ''
-          )}' is located in ${imp.path}`
-      );
+      return;
     }
 
     if (target.type === 'imprecise') {

--- a/packages/ember-auto-import/ts/tests/splitter-test.ts
+++ b/packages/ember-auto-import/ts/tests/splitter-test.ts
@@ -343,22 +343,6 @@ Qmodule('splitter', function (hooks) {
     }
   });
 
-  test('dynamic template relative imports are forbidden', async function (assert) {
-    assert.expect(1);
-    let src = 'import(`./thing/${foo}`)';
-    outputFileSync(join(project.baseDir, 'sample.js'), src);
-    await builder.build();
-    try {
-      await splitter.deps();
-      throw new Error(`expected not to get here, build was supposed to fail`);
-    } catch (err) {
-      assert.contains(
-        err.message,
-        `ember-auto-import does not support dynamic relative imports. "./thing/" is relative. To make this work, you need to upgrade to Embroider.`
-      );
-    }
-  });
-
   test('exact alias remaps package name and root', async function (assert) {
     setup({
       alias: {


### PR DESCRIPTION
This makes it so that you can do code like this: 

```js

import Route from '@ember/routing/route';
import { importSync } from '@embroider/macros';
export default Route.extend({
  model() {
    try {
      return importSync(`/a-dependency/${42}`);
      throw new Error('you should not reach this point');
    } catch (err) {
      return { message: err.message }
    }
  },
});

```

Without it breaking the build. 

This change sacrifices the clarity of the build time error for a slightly more correct implementation that allows for the above code 👍 

I discussed with @ef4 yesterday (on my Twitch live stream 😂 ) how we can bring a nicer runtime error to this scenario in the future but that will require a bit more work. 