### PR TITLE
Improve upgrade-guide

### DIFF
--- a/docs/upgrade-guide-2.0.md
+++ b/docs/upgrade-guide-2.0.md
@@ -61,7 +61,7 @@ let app = new EmberApp(defaults, {
 });
 ```
 
-You will also need to set ember-auto-import's `publicAssetURL`:
+You will also need to set ember-auto-import's `publicAssetURL` (don't forget the trailing `/assets` for `autoImport.publicAssetURL`):
 
 ```js
 let app = new EmberApp(defaults, {


### PR DESCRIPTION
Unfortunately, I missed this part as it looks very similar to `fingerprint.prepend`, but it really is important to not overlook the trailing `/assets` otherwise the url will be wrong. I wasted a couple hours with this and figured some others might miss that too. So probably a good reason to explicitly mention that.
Since I'm not a native speaker I would be happy if someone may give a better text suggestion