### PR TITLE
update package-lock.json version of htmlbars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12085,9 +12085,9 @@
       "dev": true
     },
     "node_modules/ember-cli-htmlbars": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.0.1.tgz",
-      "integrity": "sha512-IDsl9uty+MXtMfp/BUTEc/Q36EmlHYj8ZdPekcoRa8hmdsigHnK4iokfaB7dJFktlf6luruei+imv7JrJrBQPQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.1.1.tgz",
+      "integrity": "sha512-DKf2rjzIVw9zWCuFsBGJScrgf5Mz7dSg08Cq+FWFYIxnpssINUbNUoB0NHWnUJK4QqCvaExOyOmjm0kO455CPg==",
       "dependencies": {
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-ember-template-compilation": "^1.0.0",
@@ -12099,10 +12099,9 @@
         "fs-tree-diff": "^2.0.1",
         "hash-for-dep": "^1.5.1",
         "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
+        "js-string-escape": "^1.0.1",
         "semver": "^7.3.4",
         "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
         "walk-sync": "^2.2.0"
       },
       "engines": {
@@ -30978,6 +30977,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -33834,7 +33834,7 @@
       }
     },
     "packages/ember-auto-import": {
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -34057,7 +34057,7 @@
         "@embroider/addon-shim": "npm:@embroider/addon-shim@latest",
         "@embroider/macros": "npm:@embroider/macros@latest",
         "@types/fs-extra": "^5.0.4",
-        "ember-auto-import": "2.4.1",
+        "ember-auto-import": "2.4.2",
         "ember-cli": "git+https://github.com/ember-cli/ember-cli#master",
         "ember-cli-3": "npm:ember-cli@^3.0.0",
         "ember-cli-babel-older": "npm:ember-cli-babel@7.11.1",
@@ -36018,7 +36018,7 @@
         "@embroider/macros": "npm:@embroider/macros@latest",
         "@types/fs-extra": "^5.0.4",
         "@types/qunit": "^2.11.1",
-        "ember-auto-import": "2.4.1",
+        "ember-auto-import": "2.4.2",
         "ember-cli": "git+https://github.com/ember-cli/ember-cli#master",
         "ember-cli-3": "npm:ember-cli@^3.0.0",
         "ember-cli-babel-older": "npm:ember-cli-babel@7.11.1",
@@ -45726,9 +45726,9 @@
       "dev": true
     },
     "ember-cli-htmlbars": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.0.1.tgz",
-      "integrity": "sha512-IDsl9uty+MXtMfp/BUTEc/Q36EmlHYj8ZdPekcoRa8hmdsigHnK4iokfaB7dJFktlf6luruei+imv7JrJrBQPQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-6.1.1.tgz",
+      "integrity": "sha512-DKf2rjzIVw9zWCuFsBGJScrgf5Mz7dSg08Cq+FWFYIxnpssINUbNUoB0NHWnUJK4QqCvaExOyOmjm0kO455CPg==",
       "requires": {
         "@ember/edition-utils": "^1.2.0",
         "babel-plugin-ember-template-compilation": "^1.0.0",
@@ -45740,10 +45740,9 @@
         "fs-tree-diff": "^2.0.1",
         "hash-for-dep": "^1.5.1",
         "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
+        "js-string-escape": "^1.0.1",
         "semver": "^7.3.4",
         "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
         "walk-sync": "^2.2.0"
       },
       "dependencies": {
@@ -60854,7 +60853,8 @@
     "strip-bom": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",


### PR DESCRIPTION
I expect this PR to fail 😞 

I noticed that some of the ember-try scenarios are failing on my other PR https://github.com/ef4/ember-auto-import/pull/530 and I couldn't easily see why. So I wrote a little script that methodically stepped through the output of `npm outdated` and ran `npm update` on each package until it failed the same test as CI

It turns out that updating ember-cli-htmlbars is causing ember-auto-import to fail for a few of the LTS CI runs. 