### PR TITLE
Respect v2 addon's explicit external list

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -299,6 +299,10 @@ export default class WebpackBundler extends Plugin implements Bundler {
         return callback();
       }
 
+      if (pkg.meta.externals?.includes(name)) {
+        return callback(undefined, 'commonjs ' + request);
+      }
+
       try {
         let found = packageCache.resolve(name, pkg);
         if (!found.isEmberPackage() || found.isV2Addon()) {


### PR DESCRIPTION
As a compatibility feature, v2 addons are allowed to list externals in the package metadata. These are dependencies that should be resolved at runtime from the surrounding environment, not at build time. Embroider respects this option but ember-auto-import does not.