### PR TITLE
Add support for consumers using Node ES Module support (e.g. `type=module` in `package.json`)

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -133,8 +133,8 @@ export default class WebpackBundler extends Plugin implements Bundler {
     let entry: { [name: string]: string[] } = {};
     this.opts.bundles.names.forEach((bundle) => {
       entry[bundle] = [
-        join(stagingDir, 'l.js'),
-        join(stagingDir, `${bundle}.js`),
+        join(stagingDir, 'l.cjs'),
+        join(stagingDir, `${bundle}.cjs`),
       ];
     });
 
@@ -184,7 +184,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
       },
       plugins: removeUndefined([stylePlugin]),
       module: {
-        noParse: (file: string) => file === join(stagingDir, 'l.js'),
+        noParse: (file: string) => file === join(stagingDir, 'l.cjs'),
         rules: [
           this.babelRule(stagingDir),
           {
@@ -389,7 +389,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
 
   private writeEntryFile(name: string, deps: BundleDependencies) {
     writeFileSync(
-      join(this.stagingDir, `${name}.js`),
+      join(this.stagingDir, `${name}.cjs`),
       entryTemplate({
         staticImports: deps.staticImports,
         dynamicImports: deps.dynamicImports,
@@ -403,7 +403,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
   }
 
   private writeLoaderFile() {
-    writeFileSync(join(this.stagingDir, `l.js`), loader);
+    writeFileSync(join(this.stagingDir, `l.cjs`), loader);
   }
 
   private linkDeps(bundleDeps: Map<string, BundleDependencies>) {

--- a/test-scenarios/node-es-modules.ts
+++ b/test-scenarios/node-es-modules.ts
@@ -1,0 +1,44 @@
+import merge from 'lodash/merge';
+import { Scenarios } from 'scenario-tester';
+import { baseApp } from './scenarios';
+import { PreparedApp } from 'scenario-tester';
+import QUnit from 'qunit';
+const { module: Qmodule, test } = QUnit;
+
+let template = Scenarios.fromProject(baseApp);
+
+template
+  .map('node ES modules', project => {
+    project.linkDevDependency('ember-auto-import', { baseDir: __dirname });
+    // Support for ember-cli internally to respect `ember-cli-build.cjs` landed in https://github.com/ember-cli/ember-cli/pull/10053
+    project.linkDevDependency('ember-cli', { baseDir: __dirname });
+    project.linkDependency('webpack', { baseDir: __dirname });
+
+    project.files['ember-cli-build.cjs'] = project.files['ember-cli-build.js'];
+    delete project.files['ember-cli-build.js'];
+
+    project.files['testem.cjs'] = project.files['testem.js'];
+    delete project.files['testem.js'];
+
+    project.pkg.type = 'module';
+    project.pkg.scripts = project.pkg.scripts || {};
+    project.pkg.scripts.test = 'node ./node_modules/ember-cli/bin/ember test --config-file testem.cjs';
+    merge(project.files, {
+      config: {
+        'package.json': JSON.stringify({ type: 'commonjs' }),
+      },
+    });
+  })
+  .forEachScenario(scenario => {
+    Qmodule(scenario.name, function (hooks) {
+      let app: PreparedApp;
+      hooks.before(async () => {
+        app = await scenario.prepare();
+      });
+      test('npm run test', async function (assert) {
+        console.log(app.dir);
+        let result = await app.execute('volta run npm -- run test');
+        assert.equal(result.exitCode, 0, result.output);
+      });
+    });
+  });


### PR DESCRIPTION
Adds support for Ember addons that opt-in to node's ES module syntax via
type=module.

When writing to a directory whose package.json is controlled by a third
party, maximum compatibility is achieved by writing either `.cjs` or `.mjs`
files as appropriate, and not `.js` files.

If neither package is concerned with backwards compatibility, writing ES
modules into a `.js` file can be fine, but writing commonjs modules into
a `.js` file in a directory whose package.json is controlled by a third
party (e.g. another package) is not generally going to be
forwards-compatible.

See also https://github.com/ember-cli/ember-cli/pull/10053#issue-1412217269

Co-authored-by: Robert Jackson <rjackson@linkedin.com>
