### PR TITLE
Ensure chunk filenames are consistent for long-term caching

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -154,8 +154,8 @@ export default class WebpackBundler extends Plugin implements Bundler {
       output: {
         path: join(this.outputPath, 'assets'),
         publicPath: this.opts.publicAssetURL,
-        filename: `chunk.[id].[chunkhash].js`,
-        chunkFilename: `chunk.[id].[chunkhash].js`,
+        filename: `chunk.[id].[contenthash].js`,
+        chunkFilename: `chunk.[id].[contenthash].js`,
         libraryTarget: 'var',
         library: '__ember_auto_import__',
       },


### PR DESCRIPTION
Per https://webpack.js.org/configuration/output/#template-strings, `contenthash` is based on the final content of the chunk file. Given the same file contents, the filename is guaranteed to be the same.

Resolves https://github.com/ef4/ember-auto-import/issues/519