### PR TITLE
Setup style imports by default

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -189,6 +189,10 @@ export default class WebpackBundler extends Plugin implements Bundler {
           this.babelRule(stagingDir),
           {
             test: /\.css$/i,
+            use: ['style-loader', 'css-loader', 'postcss-loader'],
+          },
+          {
+            test: /\.css$/i,
             use: [
               styleLoader,
               {


### PR DESCRIPTION
Here is a demonstration of the problem: https://github.com/NullVoxPopuli/ember-style-import-test-no-embroider
The app fails at runtime with an error: 
```
vendor.js:266 Uncaught Error: Could not find module `ember-style-import-test-no-embroider/test.css` imported from `ember-style-import-test-no-embroider/app`
    at missingModule (vendor.js:266:11)
```    

I tested this change via `pnpm link`
the build told me I had to install loaders -- no dice.

When in a pre-embroider app, this custom webpack config allows folks to import CSS:
```js
autoImport: {
    webpack: {
      module = {
        rules: [
          {
            test: /\.css$/i,
            use: ['style-loader', 'css-loader', 'postcss-loader'],
          },
        ],
      },
    },
  };
```

But it seems the same configuration added to ember-auto-import does not fix the error.

What's the right way to configure this?  