### PR TITLE
Change default boot set

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -439,7 +439,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
   private getEarlyBootSet() {
     let result = this.opts.earlyBootSet
       ? this.opts.earlyBootSet([...DEFAULT_EARLY_BOOT_SET])
-      : DEFAULT_EARLY_BOOT_SET;
+      : [];
 
     /**
      * Prior to ember-source 3.27, the modules were precompiled into a variant of requirejs/AMD.


### PR DESCRIPTION
In the wake of https://github.com/ef4/ember-auto-import/issues/564 and the complexity introduced by: https://github.com/ef4/ember-auto-import/pull/566:

This PR inverts the default (intended bug fix, due to the bugs introduced by https://github.com/ef4/ember-auto-import/pull/553)

For folks that need the early boot set, you'll need to opt in.

The `earlyBootSet` is still a function, and still receives the default recommended values:
```js
autoImport: {
  earlyBootSet(defaults) {
    return [...defaults];
  }
}
```

cc @simonihmig @vitch
