### PR TITLE
Fix wrong detection of ember-source version for earlyBootSet

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -447,7 +447,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
      */
     let host = this.opts.rootPackage;
     let emberSource = host.requestedRange('ember-source');
-    let emberSourceVersion = semver.coerce(emberSource);
+    let emberSourceVersion = semver.valid(emberSource);
 
     if (emberSourceVersion && semver.lt(emberSourceVersion, '3.27.0')) {
       if (this.opts.earlyBootSet) {


### PR DESCRIPTION
When using `earlyBootSet` and running tests for Ember prerelease scenarios, these would fail with [`autoImport.earlyBootSet is not supported for ember-source <= 3.27.0`](https://github.com/CrowdStrike/ember-headless-form/actions/runs/4302373843/jobs/7500826236#step:5:163). 

Seems in this case we are trying to coerce the tarball URL from `ember-source-channel-url` into a semver version. But `semver.coerce` seems [way too forgiving](https://github.com/npm/node-semver#coercion), somehow returning `3.0.0` here. Using `valid` here instead seems to fix this, in the sense that if the package version is not something `semver` can understand, then we won't throw the error and assume it's going to be fine. 

/cc @NullVoxPopuli 