### PR TITLE
Fix missing babel-plugin-ember-template-compilation dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5104,9 +5104,9 @@
       }
     },
     "node_modules/babel-plugin-ember-template-compilation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.0.tgz",
-      "integrity": "sha512-d+4jaB2ik0rt9TH0K9kOlKJeRBHEb373FgFMcU9ZaJL2zYuVXe19bqy+cWlLpLf1tpOBcBG9QTlFBCoImlOt1g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.1.tgz",
+      "integrity": "sha512-H3+n4OQ05bLeZnwi15MGB83lcs/Lw4Zqfq2XtC4mW881zBvGftjtvRTAZN/ovNqFWtgLmo1ziSNI5/0gwsnLKw==",
       "dependencies": {
         "babel-import-util": "^1.3.0"
       },
@@ -34972,7 +34972,7 @@
       }
     },
     "packages/ember-auto-import": {
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.16.7",
@@ -34983,6 +34983,7 @@
         "@embroider/shared-internals": "^2.0.0",
         "babel-loader": "^8.0.6",
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-ember-template-compilation": "^2.0.1",
         "babel-plugin-htmlbars-inline-precompile": "^5.2.1",
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "broccoli-debug": "^0.6.4",
@@ -40973,9 +40974,9 @@
       }
     },
     "babel-plugin-ember-template-compilation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.0.tgz",
-      "integrity": "sha512-d+4jaB2ik0rt9TH0K9kOlKJeRBHEb373FgFMcU9ZaJL2zYuVXe19bqy+cWlLpLf1tpOBcBG9QTlFBCoImlOt1g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-ember-template-compilation/-/babel-plugin-ember-template-compilation-2.0.1.tgz",
+      "integrity": "sha512-H3+n4OQ05bLeZnwi15MGB83lcs/Lw4Zqfq2XtC4mW881zBvGftjtvRTAZN/ovNqFWtgLmo1ziSNI5/0gwsnLKw==",
       "requires": {
         "babel-import-util": "^1.3.0"
       }
@@ -44711,6 +44712,7 @@
         "babel-eslint": "^10.1.0",
         "babel-loader": "^8.0.6",
         "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-ember-template-compilation": "^2.0.1",
         "babel-plugin-htmlbars-inline-precompile": "^5.2.1",
         "babel-plugin-syntax-dynamic-import": "^6.18.0",
         "broccoli-debug": "^0.6.4",

--- a/packages/ember-auto-import/package.json
+++ b/packages/ember-auto-import/package.json
@@ -42,6 +42,7 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
     "babel-plugin-htmlbars-inline-precompile": "^5.2.1",
+    "babel-plugin-ember-template-compilation": "^2.0.1",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "broccoli-debug": "^0.6.4",
     "broccoli-funnel": "^3.0.8",

--- a/packages/ember-auto-import/ts/analyzer.ts
+++ b/packages/ember-auto-import/ts/analyzer.ts
@@ -192,8 +192,10 @@ export default class Analyzer extends Funnel {
       try {
         transformSync(source, options);
       } catch (err) {
-        if (err.name !== 'SyntaxError') {
-          throw err;
+        if (err instanceof Error) {
+          if (err.name !== 'SyntaxError') {
+            throw err;
+          }
         }
         debug('Ignoring an unparseable file');
       }

--- a/packages/ember-auto-import/ts/tests/analyzer-test.ts
+++ b/packages/ember-auto-import/ts/tests/analyzer-test.ts
@@ -453,10 +453,12 @@ Qmodule('analyzer', function (hooks) {
       await builder.build();
       throw new Error(`expected not to get here, build was supposed to fail`);
     } catch (err) {
-      assert.contains(
-        err.message,
-        'import() is only allowed to contain string literals or template string literals'
-      );
+      if (err instanceof Error) {
+        assert.contains(
+          err.message,
+          'import() is only allowed to contain string literals or template string literals'
+        );
+      }
     }
   });
 });

--- a/packages/ember-auto-import/ts/tests/splitter-test.ts
+++ b/packages/ember-auto-import/ts/tests/splitter-test.ts
@@ -304,10 +304,12 @@ Qmodule('splitter', function (hooks) {
       await splitter.deps();
       throw new Error(`expected not to get here, build was supposed to fail`);
     } catch (err) {
-      assert.contains(
-        err.message,
-        'Dynamic imports must target unambiguous package names'
-      );
+      if (err instanceof Error) {
+        assert.contains(
+          err.message,
+          'Dynamic imports must target unambiguous package names'
+        );
+      }
     }
   });
 
@@ -320,10 +322,12 @@ Qmodule('splitter', function (hooks) {
       await splitter.deps();
       throw new Error(`expected not to get here, build was supposed to fail`);
     } catch (err) {
-      assert.contains(
-        err.message,
-        'Dynamic imports must target unambiguous package names'
-      );
+      if (err instanceof Error) {
+        assert.contains(
+          err.message,
+          'Dynamic imports must target unambiguous package names'
+        );
+      }
     }
   });
 
@@ -336,10 +340,12 @@ Qmodule('splitter', function (hooks) {
       await splitter.deps();
       throw new Error(`expected not to get here, build was supposed to fail`);
     } catch (err) {
-      assert.contains(
-        err.message,
-        `ember-auto-import does not support dynamic relative imports. "./thing" is relative. To make this work, you need to upgrade to Embroider.`
-      );
+      if (err instanceof Error) {
+        assert.contains(
+          err.message,
+          `ember-auto-import does not support dynamic relative imports. "./thing" is relative. To make this work, you need to upgrade to Embroider.`
+        );
+      }
     }
   });
 

--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -310,6 +310,10 @@ export default class WebpackBundler extends Plugin implements Bundler {
         return callback(undefined, 'commonjs ' + request);
       }
 
+      function isModuleNotFoundError(err: any): boolean {
+        return err?.code === 'MODULE_NOT_FOUND';
+      }
+
       try {
         let found = packageCache.resolve(name, pkg);
         if (!found.isEmberPackage() || found.isV2Addon()) {
@@ -324,7 +328,7 @@ export default class WebpackBundler extends Plugin implements Bundler {
           return callback(undefined, 'commonjs ' + request);
         }
       } catch (err) {
-        if (err.code !== 'MODULE_NOT_FOUND') {
+        if (!isModuleNotFoundError(err)) {
           throw err;
         }
         // real package doesn't exist, so externalize it


### PR DESCRIPTION
Since #573 we have the possibility that we can require `babel-plugin-ember-template-compilation` so it needs to be an active dependency of ember-auto-import 

I did some digging and I couldn't quite figure out why this was not caught in our tests here in ember-auto-import but it was caught in the embroider tests 🤔 

I also have no idea why the typescript stuff was throwing errors for me when I was trying to `npm install` this change but 🤷 I made the change to make it work