### PR TITLE
fix: add fullySpecified: false to webpack config for v2 addon index.js resolution

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -234,6 +234,16 @@ export default class WebpackBundler extends Plugin implements Bundler {
       module: {
         noParse: (file: string) => file === join(stagingDir, 'l.cjs'),
         rules: [
+          // Disable webpack's strict ESM resolution for .js files. This is needed
+          // for v2 addons that use "type": "module" in package.json with directory
+          // imports like "./components/my-component" that should resolve to
+          // "./components/my-component/index.js".
+          {
+            test: /\.js$/,
+            resolve: {
+              fullySpecified: false,
+            },
+          },
           this.babelRule(
             stagingDir,
             (filename) => !this.fileIsInApp(filename),


### PR DESCRIPTION
Adds `fullySpecified: false` to webpack's module rules to support v2 addons that use `"type": "module"` in their package.json with directory imports.                                            
                                                                                                                                                                                               
  Problem                                                                                                                                                                                      
                                                                                                                                                                                               
  When a v2 addon uses `"type": "module"` in `package.json` and has internal imports without explicit `/index.js` paths, webpack 5's strict ESM resolution fails to resolve them.                    
                                                                                                                                                                                               
  Error Case (before fix)                                                                                                                                                                      
```                                                                                                                                                                                               
  Addon structure:                                                                                                                                                                             
  my-addon/                                                                                                                                                                                    
  ├── package.json          # { "type": "module", "exports": { ".": "./dist/index.js", "./*": "./dist/*" } }                                                                                   
  └── dist/                                                                                                                                                                                    
      ├── index.js          # import { foo } from './components/my-component'                                                                                                                  
      └── components/                                                                                                                                                                          
          └── my-component/                                                                                                                                                                    
              └── index.js  # export function foo() { ... }                                                                                                                                    
   ```                                                                                                                                                                                            
  Error message: 
```                                                                                                                             
  Module not found: Error: Can't resolve './components/my-component'                                                                                                                           
```  

  BREAKING CHANGE: The request './components/my-component' failed to resolve only because                                                                                                      
  it was resolved as fully specified (probably because the origin is strict EcmaScript Module,                                                                                                 
  e.g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the                                                                                                           
  package.json contains '"type": "module"').                                                                                                                                                   
  The extension in the request is mandatory for it to be fully specified.                                                                                                                      
  Add the extension to the request.                                                                                                                                                            
                                                                                                                                                                                               
  Success Case (after fix)                                                                                                                                                                     
                                                                                                                                                                                               
  The same addon structure now works correctly:                                                                                                                                                
  - import { foo } from './components/my-component' resolves to ./components/my-component/index.js                                                                                             
  - Directory imports within ESM packages work without requiring explicit /index.js suffix                                                                                                     
                                                                                                                                                                                               
  Solution                                                                                                                                                                                     
                                                                                                                                                                                               
  Add a webpack module rule that disables strict ESM resolution for .js files:                                                                                                                 
                                                                                                                                                                                               
  ```js
{                                                                                                                                                                                            
    test: /\.js$/,                                                                                                                                                                             
    resolve: {                                                                                                                                                                                 
      fullySpecified: false,                                                                                                                                                                   
    },                                                                                                                                                                                         
  },                                                                                                                                                                                           
```                
    
  - https://webpack.js.org/configuration/module/#resolvefullyspecified