### PR TITLE
fix: allow self-imports in v2 addons

### DIFF
--- a/packages/ember-auto-import/ts/webpack.ts
+++ b/packages/ember-auto-import/ts/webpack.ts
@@ -428,6 +428,13 @@ export default class WebpackBundler extends Plugin implements Bundler {
           return callback(undefined, 'commonjs ' + request);
         }
 
+        // Allow v2 addons to import from themselves using their package name.
+        // Without this, self-imports get externalized because the addon doesn't
+        // list itself as its own dependency.
+        if (name === pkg.name) {
+          return callback();
+        }
+
         if (!pkg.hasDependency(name)) {
           // v2 addons are allowed to resolve these special virtual peers from
           // the app

--- a/test-scenarios/v2-addon-test.ts
+++ b/test-scenarios/v2-addon-test.ts
@@ -259,6 +259,54 @@ function buildV2AddonWithMacros() {
   return addon;
 }
 
+// This addon tests that v2 addons can import from themselves using their package name.
+// This is important for addons that use absolute imports internally.
+function buildV2AddonWithSelfImport() {
+  let addon = new Project('addon-self-import', {
+    files: {
+      'addon-main.js': `
+        const { addonV1Shim } = require('@embroider/addon-shim');
+        module.exports = addonV1Shim(__dirname);
+      `,
+      dist: {
+        'index.js': `
+          import { addonHelper } from 'addon-self-import/utils/helper';
+          export function addonMain() {
+            return 'addon-main:' + addonHelper();
+          }
+        `,
+        utils: {
+          'helper.js': `
+            export function addonHelper() {
+              return 'addon-helper-value';
+            }
+          `,
+        },
+        components: {
+          'my-component.js': `
+            import { addonHelper } from 'addon-self-import/utils/helper';
+            export function myComponent() {
+              return 'my-component:' + addonHelper();
+            }
+          `,
+        },
+      },
+    },
+  });
+  addon.linkDependency('@embroider/addon-shim', { baseDir: __dirname });
+  addon.pkg.keywords = addon.pkg.keywords ? [...addon.pkg.keywords, 'ember-addon'] : ['ember-addon'];
+  addon.pkg['ember-addon'] = {
+    version: 2,
+    type: 'addon',
+    main: './addon-main.js',
+  };
+  addon.pkg.exports = {
+    '.': './dist/index.js',
+    './*': './dist/*',
+  };
+  return addon;
+}
+
 function buildV2AddonWithDevDep() {
   let addon = new Project('with-dev-dep', {
     files: {
@@ -301,6 +349,7 @@ let scenarios = appScenarios.skip('lts').map('v2-addon', project => {
   project.addDevDependency(buildV2AddonWithExports('fourth-v2-addon'));
   project.addDevDependency(buildV2AddonWithMacros());
   project.addDevDependency(buildV2AddonWithDevDep());
+  project.addDevDependency(buildV2AddonWithSelfImport());
 
   // apps don't necessarily need a directly dependency on @embroider/macros just
   // because they have a v2 addon that contains some macros, but in this test
@@ -482,6 +531,21 @@ let scenarios = appScenarios.skip('lts').map('v2-addon', project => {
           module('Unit | v2-addon with dev-dep', function () {
             test('should not consume dev-dep from npm', function(assert) {
                assert.ok(makeObject(), 'this will throw if we actually consume the dev dep from npm');
+            });
+          });
+        `,
+        'self-import-test.js': `
+          import { module, test } from 'qunit';
+          import { addonMain } from 'addon-self-import';
+          import { myComponent } from 'addon-self-import/components/my-component';
+
+          module('Unit | v2 addon self-import', function () {
+            test('addon can import from itself using package name', function (assert) {
+              assert.equal(addonMain(), 'addon-main:addon-helper-value', 'addon self-import should work');
+            });
+
+            test('addon component can import from addon using package name', function (assert) {
+              assert.equal(myComponent(), 'my-component:addon-helper-value', 'component self-import should work');
             });
           });
         `,


### PR DESCRIPTION
## Problem

When a v2 addon imports from itself using its own package name (e.g. `import { foo } from 'my-addon/utils/foo'` inside `my-addon`), the webpack externals handler incorrectly externalizes the import. This happens because the addon doesn't list itself as its own dependency, so the `!pkg.hasDependency(name)` check treats the self-import as an external module.

## Solution

Add a targeted check in the externals handler: when a v2 addon's code references its own package name (`name === pkg.name`), let webpack resolve it normally instead of externalizing.

This is a minimal fix that builds on top of the resolver plugin infrastructure from #705.

## Changes

- **`packages/ember-auto-import/ts/webpack.ts`**: Add self-import check in the v2 addon externals handler, before the `hasDependency` check
- **`test-scenarios/v2-addon-test.ts`**: Add `addon-self-import` test addon that uses absolute self-imports internally, with tests verifying the addon's main export and component both correctly resolve self-imports

## Test plan

- [x] All 13 v2-addon test scenarios pass (ember3, release, releaseWithModules, beta, canary, fastboot-dev, fastboot-prod, shim-requires-auto-import, cross-talk)
- [x] New self-import tests verify addon can import from itself using package name
- [x] New tests verify addon components can also self-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)